### PR TITLE
feat: Add back-end support for book photos

### DIFF
--- a/src/main/java/com/muczynski/library/controller/BookController.java
+++ b/src/main/java/com/muczynski/library/controller/BookController.java
@@ -1,7 +1,9 @@
 package com.muczynski.library.controller;
 
 import com.muczynski.library.dto.BookDto;
+import com.muczynski.library.dto.PhotoDto;
 import com.muczynski.library.service.BookService;
+import com.muczynski.library.service.PhotoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +18,9 @@ public class BookController {
 
     @Autowired
     private BookService bookService;
+
+    @Autowired
+    private PhotoService photoService;
 
     @PostMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
@@ -55,5 +60,12 @@ public class BookController {
     public ResponseEntity<Void> bulkImportBooks(@RequestBody List<BookDto> bookDtos) {
         bookService.bulkImportBooks(bookDtos);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{id}/photos")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<PhotoDto> addPhotoToBook(@PathVariable Long id, @RequestBody PhotoDto photoDto) {
+        PhotoDto created = photoService.addPhoto(id, photoDto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 }

--- a/src/main/java/com/muczynski/library/domain/Book.java
+++ b/src/main/java/com/muczynski/library/domain/Book.java
@@ -32,4 +32,7 @@ public class Book {
 
     @ManyToOne
     private Library library;
+
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
+    private java.util.List<Photo> photos;
 }

--- a/src/main/java/com/muczynski/library/domain/Photo.java
+++ b/src/main/java/com/muczynski/library/domain/Photo.java
@@ -1,0 +1,20 @@
+package com.muczynski.library.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Photo {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String url;
+
+    @ManyToOne
+    @JoinColumn(name = "book_id")
+    private Book book;
+}

--- a/src/main/java/com/muczynski/library/dto/PhotoDto.java
+++ b/src/main/java/com/muczynski/library/dto/PhotoDto.java
@@ -1,0 +1,9 @@
+package com.muczynski.library.dto;
+
+import lombok.Data;
+
+@Data
+public class PhotoDto {
+    private Long id;
+    private String url;
+}

--- a/src/main/java/com/muczynski/library/mapper/PhotoMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/PhotoMapper.java
@@ -1,0 +1,11 @@
+package com.muczynski.library.mapper;
+
+import com.muczynski.library.domain.Photo;
+import com.muczynski.library.dto.PhotoDto;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface PhotoMapper {
+    PhotoDto toDto(Photo photo);
+    Photo toEntity(PhotoDto photoDto);
+}

--- a/src/main/java/com/muczynski/library/repository/PhotoRepository.java
+++ b/src/main/java/com/muczynski/library/repository/PhotoRepository.java
@@ -1,0 +1,7 @@
+package com.muczynski.library.repository;
+
+import com.muczynski.library.domain.Photo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PhotoRepository extends JpaRepository<Photo, Long> {
+}

--- a/src/main/java/com/muczynski/library/service/PhotoService.java
+++ b/src/main/java/com/muczynski/library/service/PhotoService.java
@@ -1,0 +1,28 @@
+package com.muczynski.library.service;
+
+import com.muczynski.library.domain.Book;
+import com.muczynski.library.domain.Photo;
+import com.muczynski.library.dto.PhotoDto;
+import com.muczynski.library.mapper.PhotoMapper;
+import com.muczynski.library.repository.BookRepository;
+import com.muczynski.library.repository.PhotoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PhotoService {
+    private final PhotoRepository photoRepository;
+    private final BookRepository bookRepository;
+    private final PhotoMapper photoMapper;
+
+    @Transactional
+    public PhotoDto addPhoto(Long bookId, PhotoDto photoDto) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new RuntimeException("Book not found"));
+        Photo photo = photoMapper.toEntity(photoDto);
+        photo.setBook(book);
+        return photoMapper.toDto(photoRepository.save(photo));
+    }
+}

--- a/src/test/java/com/muczynski/library/controller/BookControllerTest.java
+++ b/src/test/java/com/muczynski/library/controller/BookControllerTest.java
@@ -2,7 +2,9 @@ package com.muczynski.library.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.muczynski.library.dto.BookDto;
+import com.muczynski.library.dto.PhotoDto;
 import com.muczynski.library.service.BookService;
+import com.muczynski.library.service.PhotoService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -33,6 +35,9 @@ class BookControllerTest {
 
     @MockitoBean
     private BookService bookService;
+
+    @MockitoBean
+    private PhotoService photoService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -118,5 +123,21 @@ class BookControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(inputDtos)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockUser(authorities = "LIBRARIAN")
+    void addPhotoToBook() throws Exception {
+        PhotoDto inputDto = new PhotoDto();
+        inputDto.setUrl("http://example.com/photo.jpg");
+        PhotoDto returnedDto = new PhotoDto();
+        returnedDto.setId(1L);
+        returnedDto.setUrl("http://example.com/photo.jpg");
+        when(photoService.addPhoto(eq(1L), any(PhotoDto.class))).thenReturn(returnedDto);
+
+        mockMvc.perform(post("/api/books/1/photos")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(inputDto)))
+                .andExpect(status().isCreated());
     }
 }

--- a/src/test/java/com/muczynski/library/service/PhotoServiceTest.java
+++ b/src/test/java/com/muczynski/library/service/PhotoServiceTest.java
@@ -1,0 +1,65 @@
+package com.muczynski.library.service;
+
+import com.muczynski.library.domain.Book;
+import com.muczynski.library.domain.Photo;
+import com.muczynski.library.dto.PhotoDto;
+import com.muczynski.library.mapper.PhotoMapper;
+import com.muczynski.library.repository.BookRepository;
+import com.muczynski.library.repository.PhotoRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PhotoServiceTest {
+
+    @Mock
+    private PhotoRepository photoRepository;
+
+    @Mock
+    private BookRepository bookRepository;
+
+    @Mock
+    private PhotoMapper photoMapper;
+
+    @InjectMocks
+    private PhotoService photoService;
+
+    @Test
+    public void testAddPhoto() {
+        // Given
+        Long bookId = 1L;
+        PhotoDto photoDto = new PhotoDto();
+        photoDto.setUrl("http://example.com/photo.jpg");
+
+        Book book = new Book();
+        book.setId(bookId);
+
+        Photo photo = new Photo();
+        photo.setUrl(photoDto.getUrl());
+        photo.setBook(book);
+
+        PhotoDto expectedPhotoDto = new PhotoDto();
+        expectedPhotoDto.setId(1L);
+        expectedPhotoDto.setUrl(photoDto.getUrl());
+
+        when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
+        when(photoMapper.toEntity(any(PhotoDto.class))).thenReturn(photo);
+        when(photoRepository.save(any(Photo.class))).thenReturn(photo);
+        when(photoMapper.toDto(any(Photo.class))).thenReturn(expectedPhotoDto);
+
+        // When
+        PhotoDto result = photoService.addPhoto(bookId, photoDto);
+
+        // Then
+        assertEquals(expectedPhotoDto.getUrl(), result.getUrl());
+    }
+}


### PR DESCRIPTION
Adds a new endpoint to upload photos for books.

- Creates a `Photo` entity and `photos` table to store photo URLs.
- Establishes a `OneToMany` relationship between `Book` and `Photo`.
- Implements a `PhotoService` to handle the business logic of adding photos.
- Adds a new endpoint `POST /api/books/{id}/photos` to the `BookController`.
- Includes JUnit tests for the new service and controller endpoint.