### PR TITLE
feat: Allow unauthenticated search

### DIFF
--- a/src/main/java/com/muczynski/library/config/SecurityConfig.java
+++ b/src/main/java/com/muczynski/library/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/test-data/generate").hasRole("LIBRARIAN")
+                        .requestMatchers("/api/search/**").permitAll()
                         .requestMatchers("/api/auth/**", "/login", "/css/**", "/js/**", "/", "/index.html", "/favicon.ico").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
This change modifies the security configuration to permit unauthenticated access to the `/api/search` endpoint.

Previously, any request to `/api/search` required authentication, resulting in a 401 Unauthorized error for users who were not logged in. This change updates `SecurityConfig.java` to include `/api/search/**` in the list of publicly accessible endpoints, resolving the issue and allowing anonymous users to use the search functionality.