### PR TITLE
feat: Support multiple photos for each book and CRUD operations

### DIFF
--- a/src/main/java/com/muczynski/library/controller/BookController.java
+++ b/src/main/java/com/muczynski/library/controller/BookController.java
@@ -62,10 +62,30 @@ public class BookController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/{id}/photos")
+    @PostMapping("/{bookId}/photos")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<PhotoDto> addPhotoToBook(@PathVariable Long id, @RequestBody PhotoDto photoDto) {
-        PhotoDto created = photoService.addPhoto(id, photoDto);
+    public ResponseEntity<PhotoDto> addPhotoToBook(@PathVariable Long bookId, @RequestBody PhotoDto photoDto) {
+        PhotoDto created = photoService.addPhoto(bookId, photoDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+
+    @GetMapping("/{bookId}/photos")
+    public ResponseEntity<List<PhotoDto>> getPhotosByBook(@PathVariable Long bookId) {
+        List<PhotoDto> photos = photoService.getPhotosByBookId(bookId);
+        return ResponseEntity.ok(photos);
+    }
+
+    @PutMapping("/{bookId}/photos/{photoId}")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<PhotoDto> updatePhoto(@PathVariable Long bookId, @PathVariable Long photoId, @RequestBody PhotoDto photoDto) {
+        PhotoDto updated = photoService.updatePhoto(photoId, photoDto);
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/{bookId}/photos/{photoId}")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<Void> deletePhoto(@PathVariable Long bookId, @PathVariable Long photoId) {
+        photoService.deletePhoto(photoId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/muczynski/library/repository/PhotoRepository.java
+++ b/src/main/java/com/muczynski/library/repository/PhotoRepository.java
@@ -3,5 +3,8 @@ package com.muczynski.library.repository;
 import com.muczynski.library.domain.Photo;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
+    List<Photo> findByBookId(Long bookId);
 }

--- a/src/main/java/com/muczynski/library/service/PhotoService.java
+++ b/src/main/java/com/muczynski/library/service/PhotoService.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class PhotoService {
@@ -24,5 +27,26 @@ public class PhotoService {
         Photo photo = photoMapper.toEntity(photoDto);
         photo.setBook(book);
         return photoMapper.toDto(photoRepository.save(photo));
+    }
+
+    @Transactional(readOnly = true)
+    public List<PhotoDto> getPhotosByBookId(Long bookId) {
+        List<Photo> photos = photoRepository.findByBookId(bookId);
+        return photos.stream()
+                .map(photoMapper::toDto)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public PhotoDto updatePhoto(Long photoId, PhotoDto photoDto) {
+        Photo photo = photoRepository.findById(photoId)
+                .orElseThrow(() -> new RuntimeException("Photo not found"));
+        photo.setUrl(photoDto.getUrl());
+        return photoMapper.toDto(photoRepository.save(photo));
+    }
+
+    @Transactional
+    public void deletePhoto(Long photoId) {
+        photoRepository.deleteById(photoId);
     }
 }


### PR DESCRIPTION
This commit introduces full CRUD (Create, Read, Update, Delete) functionality for photos associated with books.

- Extended `PhotoService` to include methods for adding, retrieving, updating, and deleting photos.
- Added a `findByBookId` method to `PhotoRepository` to fetch all photos for a given book.
- Updated `BookController` to expose RESTful endpoints for all photo operations.
- Secured the modification endpoints (`POST`, `PUT`, `DELETE`) to ensure only users with the 'LIBRARIAN' role can make changes.