### PR TITLE
Refactor photo storage to use base64 encoding

### DIFF
--- a/src/main/java/com/muczynski/library/domain/Photo.java
+++ b/src/main/java/com/muczynski/library/domain/Photo.java
@@ -12,7 +12,9 @@ public class Photo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String url;
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String base64;
 
     @ManyToOne
     @JoinColumn(name = "book_id")

--- a/src/main/java/com/muczynski/library/dto/PhotoDto.java
+++ b/src/main/java/com/muczynski/library/dto/PhotoDto.java
@@ -5,5 +5,5 @@ import lombok.Data;
 @Data
 public class PhotoDto {
     private Long id;
-    private String url;
+    private String base64;
 }

--- a/src/main/java/com/muczynski/library/service/PhotoService.java
+++ b/src/main/java/com/muczynski/library/service/PhotoService.java
@@ -41,7 +41,7 @@ public class PhotoService {
     public PhotoDto updatePhoto(Long photoId, PhotoDto photoDto) {
         Photo photo = photoRepository.findById(photoId)
                 .orElseThrow(() -> new RuntimeException("Photo not found"));
-        photo.setUrl(photoDto.getUrl());
+        photo.setBase64(photoDto.getBase64());
         return photoMapper.toDto(photoRepository.save(photo));
     }
 

--- a/src/test/java/com/muczynski/library/controller/BookControllerTest.java
+++ b/src/test/java/com/muczynski/library/controller/BookControllerTest.java
@@ -129,10 +129,10 @@ class BookControllerTest {
     @WithMockUser(authorities = "LIBRARIAN")
     void addPhotoToBook() throws Exception {
         PhotoDto inputDto = new PhotoDto();
-        inputDto.setUrl("http://example.com/photo.jpg");
+        inputDto.setBase64("dGVzdFBob3Rv");
         PhotoDto returnedDto = new PhotoDto();
         returnedDto.setId(1L);
-        returnedDto.setUrl("http://example.com/photo.jpg");
+        returnedDto.setBase64("dGVzdFBob3Rv");
         when(photoService.addPhoto(eq(1L), any(PhotoDto.class))).thenReturn(returnedDto);
 
         mockMvc.perform(post("/api/books/1/photos")

--- a/src/test/java/com/muczynski/library/service/PhotoServiceTest.java
+++ b/src/test/java/com/muczynski/library/service/PhotoServiceTest.java
@@ -38,18 +38,18 @@ public class PhotoServiceTest {
         // Given
         Long bookId = 1L;
         PhotoDto photoDto = new PhotoDto();
-        photoDto.setUrl("http://example.com/photo.jpg");
+        photoDto.setBase64("dGVzdFBob3Rv");
 
         Book book = new Book();
         book.setId(bookId);
 
         Photo photo = new Photo();
-        photo.setUrl(photoDto.getUrl());
+        photo.setBase64(photoDto.getBase64());
         photo.setBook(book);
 
         PhotoDto expectedPhotoDto = new PhotoDto();
         expectedPhotoDto.setId(1L);
-        expectedPhotoDto.setUrl(photoDto.getUrl());
+        expectedPhotoDto.setBase64(photoDto.getBase64());
 
         when(bookRepository.findById(bookId)).thenReturn(Optional.of(book));
         when(photoMapper.toEntity(any(PhotoDto.class))).thenReturn(photo);
@@ -60,6 +60,6 @@ public class PhotoServiceTest {
         PhotoDto result = photoService.addPhoto(bookId, photoDto);
 
         // Then
-        assertEquals(expectedPhotoDto.getUrl(), result.getUrl());
+        assertEquals(expectedPhotoDto.getBase64(), result.getBase64());
     }
 }


### PR DESCRIPTION
This commit modifies the photo storage mechanism to store the photo data as a base64 encoded string directly in the database, instead of storing a URL to the photo.

The following changes were made:
- The `Photo` entity was updated to replace the `url` field with a `base64` field, annotated with `@Lob` to handle large strings.
- The `PhotoDto` was updated to match the new `Photo` entity.
- The `PhotoService` was updated to use the new `base64` field.
- The tests for `BookController` and `PhotoService` were updated to reflect the changes.