### PR TITLE
feat: Display and allow deletion of book photos

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -129,6 +129,10 @@
         <div id="books-section" class="section" data-test="books-section">
             <h2 data-test="books-header">Books</h2>
             <ul id="book-list" class="list-group mb-3" data-test="book-list"></ul>
+            <div id="book-photos-container" class="mb-3" style="display: none;" data-test="book-photos-container">
+                <h3 data-test="book-photos-header">Book Photos</h3>
+                <div id="book-photos" data-test="book-photos"></div>
+            </div>
             <div class="librarian-only" data-test="books-form">
                 <div class="mb-3">
                     <label for="new-book-title" class="form-label">Book Title:</label>


### PR DESCRIPTION
This commit introduces the functionality to display and delete photos associated with a book on the book edit page.

- Adds a photo display area to the book edit page.
- Fetches and displays book photos when a book is being edited.
- Photos are displayed at 60% of the webpage width.
- A delete icon is provided for each photo to allow for its removal.
- The photo display is hidden when adding a new book or when a book has no photos.