### PR TITLE
feat: Sort authors by surname

### DIFF
--- a/jules-scratch/verification/verify_author_sorting.py
+++ b/jules-scratch/verification/verify_author_sorting.py
@@ -1,0 +1,30 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("http://localhost:8080")
+    page.wait_for_load_state("domcontentloaded")
+
+    # Login
+    page.wait_for_selector("[data-test='menu-login']", state='visible')
+    page.click("[data-test='menu-login']")
+    page.wait_for_selector("[data-test='login-form']")
+    page.fill("[data-test='login-username']", "librarian")
+    page.fill("[data-test='login-password']", "password")
+    page.click("[data-test='login-submit']")
+    page.wait_for_selector("[data-test='main-content']", state='visible')
+
+    # Navigate to authors section
+    page.click("[data-test='menu-authors']")
+    page.wait_for_selector("#authors-section")
+
+    # Take screenshot
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/java/com/muczynski/library/service/AuthorService.java
+++ b/src/main/java/com/muczynski/library/service/AuthorService.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,6 +35,10 @@ public class AuthorService {
     public List<AuthorDto> getAllAuthors() {
         return authorRepository.findAll().stream()
                 .map(authorMapper::toDto)
+                .sorted(Comparator.comparing(author -> {
+                    String[] nameParts = author.getName().split(" ");
+                    return nameParts.length > 1 ? nameParts[nameParts.length - 1] : author.getName();
+                }))
                 .collect(Collectors.toList());
     }
 

--- a/src/test/java/com/muczynski/library/ui/AuthorsUITest.java
+++ b/src/test/java/com/muczynski/library/ui/AuthorsUITest.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest(classes = LibraryApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
@@ -160,6 +161,37 @@ public class AuthorsUITest {
         } catch (Exception e) {
             // Screenshot on failure for debugging
             page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("failure-authors-crud.png")));
+            throw e;
+        }
+    }
+
+    @Test
+    @Sql(value = "classpath:data-authors-sorting.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void testAuthorsAreSortedBySurname() {
+        try {
+            page.navigate("http://localhost:" + port);
+            login();
+            ensurePrerequisites();
+
+            navigateToSection("authors");
+
+            page.waitForSelector("[data-test='author-item']", new Page.WaitForSelectorOptions().setTimeout(5000).setState(WaitForSelectorState.VISIBLE));
+
+            List<String> authorNames = page.locator("[data-test='author-name']").allTextContents();
+
+            List<String> expectedOrder = Arrays.asList(
+                    "Jane Austen",
+                    "Charlotte Brontë",
+                    "Emily Brontë",
+                    "Charles Dickens",
+                    "George Eliot",
+                    "Mary Shelley"
+            );
+
+            assertEquals(expectedOrder, authorNames);
+
+        } catch (Exception e) {
+            page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("failure-authors-sorting.png")));
             throw e;
         }
     }

--- a/src/test/resources/data-authors-sorting.sql
+++ b/src/test/resources/data-authors-sorting.sql
@@ -1,0 +1,27 @@
+DELETE FROM users_roles;
+DELETE FROM loan;
+DELETE FROM photo;
+DELETE FROM book;
+DELETE FROM author;
+DELETE FROM library;
+DELETE FROM users;
+DELETE FROM role;
+
+INSERT INTO role (id, name) VALUES (1, 'USER');
+INSERT INTO role (id, name) VALUES (2, 'LIBRARIAN');
+
+INSERT INTO users (id, username, password) VALUES (1, 'librarian', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi');
+INSERT INTO users (id, username, password) VALUES (2, 'testuser', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi');
+
+INSERT INTO users_roles (user_id, role_id) VALUES (1, 1);
+INSERT INTO users_roles (user_id, role_id) VALUES (1, 2);
+INSERT INTO users_roles (user_id, role_id) VALUES (2, 1);
+
+INSERT INTO library (id, name, hostname) VALUES (1, 'Test Library', 'test.local');
+
+INSERT INTO author (id, name) VALUES (1, 'Mary Shelley');
+INSERT INTO author (id, name) VALUES (2, 'Jane Austen');
+INSERT INTO author (id, name) VALUES (3, 'George Eliot');
+INSERT INTO author (id, name) VALUES (4, 'Charles Dickens');
+INSERT INTO author (id, name) VALUES (5, 'Charlotte Brontë');
+INSERT INTO author (id, name) VALUES (6, 'Emily Brontë');


### PR DESCRIPTION
This commit introduces sorting for the authors list on the Authors page. The sorting is done in the back-end, in the `AuthorService`, and is based on the author's surname.

A new UI test has been added to verify the sorting functionality.