### PR TITLE
feat: Add numbering to book search results

### DIFF
--- a/jules-scratch/verification/verify_search_numbering.py
+++ b/jules-scratch/verification/verify_search_numbering.py
@@ -1,0 +1,46 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run_verification():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context()
+        page = context.new_page()
+
+        try:
+            # 1. Arrange: Go to the application homepage.
+            page.goto("http://localhost:8080")
+
+            # Login
+            page.click("[data-test='menu-login']")
+            page.wait_for_selector("[data-test='login-form']", state='visible', timeout=60000)
+            page.fill("[data-test='login-username']", "librarian")
+            page.fill("[data-test='login-password']", "password")
+            page.click("[data-test='login-submit']")
+            page.wait_for_selector("[data-test='main-content']", state='visible', timeout=60000)
+            page.wait_for_timeout(1000) # Wait for 1 second
+
+            # 2. Act: Navigate to the search page and perform a search.
+            page.click("[data-test='menu-search']")
+            page.wait_for_selector("[data-test='search-section']", state='visible', timeout=60000)
+            page.fill("[data-test='search-input']", "a")
+            page.click("[data-test='search-btn']")
+            page.wait_for_selector("[data-test='search-results']", state='visible', timeout=60000)
+
+            # 3. Assert: Check if the book numbers are displayed correctly.
+            # Wait for the search results to load
+            expect(page.locator("[data-test='search-books-list']")).to_be_visible(timeout=60000)
+
+            # Check the header
+            expect(page.locator("h4:has-text('Books 1 - 20')")).to_be_visible(timeout=60000)
+
+            # Check the first book
+            expect(page.locator("[data-test='search-book-item']").first).to_contain_text("1.", timeout=60000)
+
+            # 4. Screenshot: Capture the final result for visual verification.
+            page.screenshot(path="jules-scratch/verification/verification.png")
+
+        finally:
+            browser.close()
+
+if __name__ == "__main__":
+    run_verification()

--- a/src/main/resources/static/js/search.js
+++ b/src/main/resources/static/js/search.js
@@ -28,19 +28,21 @@ function displaySearchResults(books, authors, query, bookPage, authorPage) {
     }
 
     if (books.length > 0) {
+        const startBook = currentPage * pageSize + 1;
+        const endBook = currentPage * pageSize + books.length;
         const booksHeader = document.createElement('h4');
-        booksHeader.textContent = 'Books';
+        booksHeader.textContent = `Books ${startBook} - ${endBook}`;
         resultsDiv.appendChild(booksHeader);
 
         const booksList = document.createElement('ul');
         booksList.className = 'list-group mb-3';
         booksList.setAttribute('data-test', 'search-books-list');
-        books.forEach(book => {
+        books.forEach((book, index) => {
             const li = document.createElement('li');
             li.className = 'list-group-item d-flex justify-content-between align-items-center';
             li.setAttribute('data-test', 'search-book-item');
             const span = document.createElement('span');
-            span.textContent = book.title;
+            span.textContent = `${startBook + index}. ${book.title}`;
             li.appendChild(span);
             const viewBtn = document.createElement('button');
             viewBtn.className = 'btn btn-sm btn-outline-primary ms-2';


### PR DESCRIPTION
This commit updates the search results page to display a number next to each book, indicating its order in the list. The "Books" header has also been updated to show the range of book numbers currently being displayed.

The changes are implemented in the `displaySearchResults` function in `src/main/resources/static/js/search.js`. The book numbers are calculated on the front-end based on the current page and page size.