### PR TITLE
feat: Sort loans by due date

### DIFF
--- a/src/main/java/com/muczynski/library/repository/LoanRepository.java
+++ b/src/main/java/com/muczynski/library/repository/LoanRepository.java
@@ -4,7 +4,11 @@ import com.muczynski.library.domain.Loan;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface LoanRepository extends JpaRepository<Loan, Long> {
     long countByBookId(Long bookId);
+
+    List<Loan> findAllByOrderByReturnDateAsc();
 }

--- a/src/main/java/com/muczynski/library/service/LoanService.java
+++ b/src/main/java/com/muczynski/library/service/LoanService.java
@@ -55,7 +55,7 @@ public class LoanService {
     }
 
     public List<LoanDto> getAllLoans() {
-        return loanRepository.findAll().stream()
+        return loanRepository.findAllByOrderByReturnDateAsc().stream()
                 .map(loanMapper::toDto)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Sorts the list of loans in chronological order by their due date.

The sorting is implemented in the backend by adding a new method to the `LoanRepository` that retrieves loans sorted by their return date. The `LoanService` is updated to use this new method.