### PR TITLE
feat: Add XAI_API_KEY to User entity

### DIFF
--- a/src/main/java/com/muczynski/library/domain/User.java
+++ b/src/main/java/com/muczynski/library/domain/User.java
@@ -18,6 +18,8 @@ public class User {
     private String username;
     private String password;
 
+    private String xaiApiKey = "";
+
     @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
             name = "users_roles",


### PR DESCRIPTION
Adds a field to the User entity to store an XAI_API_KEY, defaulting to a blank string.