### PR TITLE
feat: Add numbering to author search results

### DIFF
--- a/jules-scratch/verification/verify_search.py
+++ b/jules-scratch/verification/verify_search.py
@@ -1,0 +1,39 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        page.goto("http://localhost:8080")
+
+        # Login
+        page.locator("[data-test='menu-login']").click()
+        page.locator("[data-test='login-username']").fill("librarian")
+        page.locator("[data-test='login-password']").fill("librarian")
+        page.locator("[data-test='login-submit']").click()
+        page.wait_for_selector("[data-test='main-content']")
+
+        # Navigate to authors and add some
+        page.locator("[data-test='menu-authors']").click()
+        page.locator("[data-test='bulk-authors']").fill('[{"name": "Author 1"}, {"name": "Author 2"}]')
+        page.locator("[data-test='bulk-import-authors-btn']").click()
+
+        # Navigate to search
+        page.locator("[data-test='menu-search']").click()
+
+        # Perform search
+        page.locator("[data-test='search-input']").fill("Author")
+        page.locator("[data-test='search-btn']").click()
+
+        page.wait_for_selector("[data-test='search-authors-list']")
+
+        # Take screenshot
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/resources/static/js/search.js
+++ b/src/main/resources/static/js/search.js
@@ -56,19 +56,21 @@ function displaySearchResults(books, authors, query, bookPage, authorPage) {
     }
 
     if (authors.length > 0) {
+        const startAuthor = authorPage.pageable.offset + 1;
+        const endAuthor = authorPage.pageable.offset + authors.length;
         const authorsHeader = document.createElement('h4');
-        authorsHeader.textContent = 'Authors';
+        authorsHeader.textContent = `Authors ${startAuthor} - ${endAuthor}`;
         resultsDiv.appendChild(authorsHeader);
 
         const authorsList = document.createElement('ul');
         authorsList.className = 'list-group mb-3';
         authorsList.setAttribute('data-test', 'search-authors-list');
-        authors.forEach(author => {
+        authors.forEach((author, index) => {
             const li = document.createElement('li');
             li.className = 'list-group-item d-flex justify-content-between align-items-center';
             li.setAttribute('data-test', 'search-author-item');
             const span = document.createElement('span');
-            span.textContent = author.name;
+            span.textContent = `${startAuthor + index}. ${author.name}`;
             li.appendChild(span);
             const viewBtn = document.createElement('button');
             viewBtn.className = 'btn btn-sm btn-outline-primary ms-2';


### PR DESCRIPTION
This commit adds numbering to the author search results and updates the header to show the range of authors being displayed.

- The `displaySearchResults` function in `search.js` is modified to calculate the start and end numbers for the author list.
- The 'Authors' header is updated to display the calculated range (e.g., "Authors 1 - 20").
- The author list is modified to include the author's number before their name.