### PR TITLE
feat: Display loans in a table

### DIFF
--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -224,7 +224,17 @@
 
         <div id="loans-section" class="section librarian-only" data-test="loans-section">
             <h2 data-test="loans-header">Loans</h2>
-            <ul id="loan-list" class="list-group mb-3" data-test="loan-list"></ul>
+            <table class="table" data-test="loan-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Loan</th>
+                        <th scope="col">Due Date</th>
+                        <th scope="col">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="loan-list-body" data-test="loan-list-body">
+                </tbody>
+            </table>
             <div data-test="loans-form">
                 <div class="mb-3">
                     <label for="loan-book" class="form-label">Book:</label>

--- a/src/test/java/com/muczynski/library/ui/LoansUITest.java
+++ b/src/test/java/com/muczynski/library/ui/LoansUITest.java
@@ -121,10 +121,16 @@ public class LoansUITest {
             // Navigate to loans section and assert visibility
             navigateToSection("loans");
 
+            // Assert that the table is visible
+            assertThat(page.locator("[data-test='loan-table']")).isVisible();
+
             // Delete any existing loans to ensure clean state
             Locator loanList = page.locator("[data-test='loan-item']");
-            if (loanList.count() > 0) {
-                loanList.first().locator("[data-test='delete-loan-btn']").click();
+            int initialCount = loanList.count();
+            if (initialCount > 0) {
+                for (int i = 0; i < initialCount; i++) {
+                    loanList.first().locator("[data-test='delete-loan-btn']").click();
+                }
                 assertThat(loanList).hasCount(0, new LocatorAssertions.HasCountOptions().setTimeout(5000));
             }
 
@@ -143,6 +149,9 @@ public class LoansUITest {
             loanItem.first().waitFor(new Locator.WaitForOptions().setTimeout(5000));
             assertThat(loanItem.first()).isVisible();
             assertThat(loanItem).hasCount(1);
+
+            // Assert due date is present
+            assertThat(loanItem.locator("[data-test='loan-due-date']")).containsText("/");
 
             // Update: Change loan date instead of user (backend doesn't support user update)
             loanItem.first().locator("[data-test='edit-loan-btn']").click();


### PR DESCRIPTION
Refactors the loans page to display loans in a table with columns for loan details, due date, and actions.

- Replaces the `<ul>` with a `<table>` in `index.html`.
- Updates `loans.js` to populate the table.
- Updates `LoansUITest.java` to reflect the UI changes.