### PR TITLE
Refactor: Display users in a table

### DIFF
--- a/-
+++ b/-
@@ -1,0 +1,1 @@
+Downloading https://services.gradle.org/distributions/gradle-8.14-bin.zip

--- a/jules-scratch/verification/verify_users_page.py
+++ b/jules-scratch/verification/verify_users_page.py
@@ -1,0 +1,27 @@
+from playwright.sync_api import sync_playwright, Page, expect
+import time
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("http://localhost:8080")
+    page.click("[data-test='menu-login']")
+    page.fill("[data-test='login-username']", "librarian")
+    page.fill("[data-test='login-password']", "password")
+    page.click("[data-test='login-submit']")
+    time.sleep(2) # Give page time to react
+    page.screenshot(path="jules-scratch/verification/after_login_attempt.png")
+    page.wait_for_selector("[data-test='welcome-screen']", state='hidden')
+    page.wait_for_selector("[data-test='main-content']")
+
+    page.click("[data-test='menu-users']")
+    page.wait_for_selector("[data-test='users-section']")
+
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -201,7 +201,16 @@
 
         <div id="users-section" class="section librarian-only" data-test="users-section">
             <h2 data-test="users-header">Users</h2>
-            <ul id="user-list" class="list-group mb-3" data-test="user-list"></ul>
+            <table class="table" data-test="user-table">
+                <thead>
+                    <tr>
+                        <th scope="col">User</th>
+                        <th scope="col">Actions</th>
+                    </tr>
+                </thead>
+                <tbody id="user-list-body" data-test="user-list-body">
+                </tbody>
+            </table>
             <form data-test="users-form">
                 <div class="mb-3">
                     <label for="new-user-username" class="form-label">Username:</label>

--- a/src/main/resources/static/js/users.js
+++ b/src/main/resources/static/js/users.js
@@ -1,39 +1,45 @@
 async function loadUsers() {
     try {
         const users = await fetchData('/api/users');
-        const list = document.getElementById('user-list');
-        list.innerHTML = '';
+        const tableBody = document.getElementById('user-list-body');
+        tableBody.innerHTML = '';
         users.forEach(user => {
-            const li = document.createElement('li');
-            li.setAttribute('data-test', 'user-item');
-            li.setAttribute('data-entity-id', user.id);
+            const row = document.createElement('tr');
+            row.setAttribute('data-test', 'user-item');
+            row.setAttribute('data-entity-id', user.id);
+
+            const userCell = document.createElement('td');
             const span = document.createElement('span');
             span.setAttribute('data-test', 'user-name');
             const rolesText = user.roles ? Array.from(user.roles).join(', ') : '';
             span.textContent = `${user.username} (${rolesText})`;
-            li.appendChild(span);
+            userCell.appendChild(span);
+            row.appendChild(userCell);
+
+            const actionsCell = document.createElement('td');
 
             const viewBtn = document.createElement('button');
             viewBtn.setAttribute('data-test', 'view-user-btn');
             viewBtn.textContent = '🔍';
             viewBtn.title = 'View details';
             viewBtn.onclick = () => viewUser(user.id);
-            li.appendChild(viewBtn);
+            actionsCell.appendChild(viewBtn);
 
             const editBtn = document.createElement('button');
             editBtn.setAttribute('data-test', 'edit-user-btn');
             editBtn.textContent = '✏️';
             editBtn.title = 'Edit';
             editBtn.onclick = () => editUser(user.id);
-            li.appendChild(editBtn);
+            actionsCell.appendChild(editBtn);
 
             const delBtn = document.createElement('button');
             delBtn.setAttribute('data-test', 'delete-user-btn');
             delBtn.textContent = '🗑️';
             delBtn.title = 'Delete';
             delBtn.onclick = () => deleteUser(user.id);
-            li.appendChild(delBtn);
-            list.appendChild(li);
+            actionsCell.appendChild(delBtn);
+            row.appendChild(actionsCell);
+            tableBody.appendChild(row);
         });
         clearError('users');
     } catch (error) {

--- a/src/test/java/com/muczynski/library/ui/UsersUITest.java
+++ b/src/test/java/com/muczynski/library/ui/UsersUITest.java
@@ -130,8 +130,8 @@ public class UsersUITest {
             page.click("[data-test='add-user-btn']");
 
             // Read: Use filter for flexible matching
-            Locator userList = page.locator("[data-test='user-item']");
-            Locator userItem = userList.filter(new Locator.FilterOptions().setHasText(uniqueUsername));
+            Locator userTable = page.locator("[data-test='user-table']");
+            Locator userItem = userTable.locator("[data-test='user-item']").filter(new Locator.FilterOptions().setHasText(uniqueUsername));
             userItem.first().waitFor(new Locator.WaitForOptions().setTimeout(5000));
             assertThat(userItem.first()).isVisible();
             assertThat(userItem).hasCount(1);
@@ -150,23 +150,23 @@ public class UsersUITest {
 
             // Wait for the updated item to appear (confirms reload)
             page.waitForLoadState(LoadState.DOMCONTENTLOADED);
-            Locator updatedUserItem = userList.filter(new Locator.FilterOptions().setHasText(updatedUsername));
+            Locator updatedUserItem = userTable.locator("[data-test='user-item']").filter(new Locator.FilterOptions().setHasText(updatedUsername));
             updatedUserItem.first().waitFor(new Locator.WaitForOptions().setTimeout(10000));
             assertThat(updatedUserItem.first()).isVisible();
 
             // Assert old item is gone (confirms successful reload without detach wait)
-            assertThat(userList.filter(new Locator.FilterOptions().setHasText(uniqueUsername))).hasCount(0, new LocatorAssertions.HasCountOptions().setTimeout(5000));
+            assertThat(userTable.locator("[data-test='user-item']").filter(new Locator.FilterOptions().setHasText(uniqueUsername))).hasCount(0, new LocatorAssertions.HasCountOptions().setTimeout(5000));
 
             // Delete
-            Locator toDelete = userList.filter(new Locator.FilterOptions().setHasText(updatedUsername));
-            int initialCount = userList.count();
+            Locator toDelete = userTable.locator("[data-test='user-item']").filter(new Locator.FilterOptions().setHasText(updatedUsername));
+            int initialCount = userTable.locator("[data-test='user-item']").count();
             page.onDialog(dialog -> dialog.accept());
             toDelete.first().locator("[data-test='delete-user-btn']").click();
 
             // Wait for the user count to decrease
             page.waitForFunction("() => document.querySelectorAll(\"[data-test='user-item']\").length < " + initialCount);
 
-            assertThat(userList.filter(new Locator.FilterOptions().setHasText(updatedUsername))).hasCount(0);
+            assertThat(userTable.locator("[data-test='user-item']").filter(new Locator.FilterOptions().setHasText(updatedUsername))).hasCount(0);
 
         } catch (Exception e) {
             // Screenshot on failure for debugging


### PR DESCRIPTION
This commit refactors the Users page to display the list of users in a table with two columns. The first column shows the user's information, and the second column contains the action buttons.

The corresponding UI test has been updated to reflect the new table structure.