### PR TITLE
Fix: Set default loan and due dates on Loans page

### DIFF
--- a/jules-scratch/verification/verify_default_dates.py
+++ b/jules-scratch/verification/verify_default_dates.py
@@ -1,0 +1,61 @@
+from playwright.sync_api import sync_playwright, expect
+import datetime
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        print("Navigating to the page...")
+        page.goto("http://localhost:8080")
+        page.wait_for_load_state("networkidle")
+        print("Page loaded.")
+
+        print("Clicking login menu button...")
+        page.click("[data-test='menu-login']")
+        print("Login menu button clicked.")
+
+        print("Filling in login form...")
+        page.fill("[data-test='login-username']", "librarian")
+        page.fill("[data-test='login-password']", "password")
+        print("Login form filled.")
+
+        print("Clicking login submit button...")
+        page.click("[data-test='login-submit']")
+        print("Login submit button clicked.")
+
+        print("Waiting for URL to change...")
+        page.wait_for_url("http://localhost:8080/")
+        print("URL changed.")
+
+
+        print("Waiting for main content to be visible...")
+        page.wait_for_selector("[data-test='main-content']", state='visible')
+        print("Main content is visible.")
+
+        print("Clicking loans menu button...")
+        page.click("[data-test='menu-loans']")
+        print("Loans menu button clicked.")
+
+        print("Waiting for loans section to be visible...")
+        page.wait_for_selector("[data-test='loans-section']", state='visible')
+        print("Loans section is visible.")
+
+        loan_date_input = page.locator("[data-test='loans-form'] [data-test='loan-date']")
+        due_date_input = page.locator("[data-test='loans-form'] [data-test='due-date']")
+
+        today = datetime.date.today()
+        two_weeks = today + datetime.timedelta(days=14)
+
+        expect(loan_date_input).to_have_value(today.strftime('%Y-%m-%d'))
+        expect(due_date_input).to_have_value(two_weeks.strftime('%Y-%m-%d'))
+
+        page.screenshot(path="jules-scratch/verification/verification.png")
+        print("Screenshot taken.")
+
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/resources/static/js/loans.js
+++ b/src/main/resources/static/js/loans.js
@@ -194,6 +194,17 @@ async function populateLoanDropdowns() {
             option.textContent = user.username;
             userSelect.appendChild(option);
         });
+
+        const loanDateInput = document.getElementById('loan-date');
+        const dueDateInput = document.getElementById('due-date');
+
+        const today = new Date();
+        loanDateInput.value = today.toISOString().split('T')[0];
+
+        const twoWeeksFromNow = new Date(today);
+        twoWeeksFromNow.setDate(today.getDate() + 14);
+        dueDateInput.value = twoWeeksFromNow.toISOString().split('T')[0];
+
     } catch (error) {
         showError('loans', 'Failed to populate dropdowns: ' + error.message);
     }

--- a/src/test/java/com/muczynski/library/ui/LoansUITest.java
+++ b/src/test/java/com/muczynski/library/ui/LoansUITest.java
@@ -199,4 +199,28 @@ public class LoansUITest {
             throw e;
         }
     }
+
+    @Test
+    void testDefaultLoanDates() {
+        try {
+            page.navigate("http://localhost:" + port);
+            login();
+            navigateToSection("loans");
+
+            page.waitForSelector("[data-test='loan-date']", new Page.WaitForSelectorOptions().setTimeout(5000).setState(WaitForSelectorState.VISIBLE));
+
+            String loanDateValue = page.locator("[data-test='loans-form'] [data-test='loan-date']").inputValue();
+            String dueDateValue = page.locator("[data-test='loans-form'] [data-test='due-date']").inputValue();
+
+            java.time.LocalDate today = java.time.LocalDate.now();
+            java.time.LocalDate twoWeeksFromNow = today.plusDays(14);
+
+            assertEquals(today.toString(), loanDateValue);
+            assertEquals(twoWeeksFromNow.toString(), dueDateValue);
+
+        } catch (Exception e) {
+            page.screenshot(new Page.ScreenshotOptions().setPath(Paths.get("failure-default-dates.png")));
+            throw e;
+        }
+    }
 }


### PR DESCRIPTION
The loan and due date fields on the Loans page were not being populated with default values, showing placeholder text instead.

This commit fixes the issue by adding JavaScript to the `populateLoanDropdowns` function in `loans.js`. The script now sets the loan date to the current date and the due date to two weeks from the current date.

A new UI test, `testDefaultLoanDates`, has been added to `LoansUITest.java` to verify that the default dates are correctly set on page load.