### PR TITLE
feat: Implement library card application system

### DIFF
--- a/jules-scratch/verification/verify_apply_for_card.py
+++ b/jules-scratch/verification/verify_apply_for_card.py
@@ -1,0 +1,19 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("http://localhost:8080/apply-for-card.html")
+
+    print(page.content())
+
+    expect(page).to_have_title("Apply for a Library Card")
+
+    page.screenshot(path="jules-scratch/verification/apply-for-card.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/java/com/muczynski/library/config/SecurityConfig.java
+++ b/src/main/java/com/muczynski/library/config/SecurityConfig.java
@@ -32,8 +32,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/test-data/generate").hasAuthority("LIBRARIAN")
+                        .requestMatchers("/apply/api/**").hasAuthority("LIBRARIAN")
                         .requestMatchers("/api/search/**").permitAll()
-                        .requestMatchers("/api/auth/**", "/login", "/css/**", "/js/**", "/", "/index.html", "/favicon.ico").permitAll()
+                        .requestMatchers("/api/auth/**", "/login", "/css/**", "/js/**", "/", "/index.html", "/favicon.ico", "/apply-for-card.html", "/apply").permitAll()
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))

--- a/src/main/java/com/muczynski/library/controller/AppliedController.java
+++ b/src/main/java/com/muczynski/library/controller/AppliedController.java
@@ -1,0 +1,65 @@
+package com.muczynski.library.controller;
+
+import com.muczynski.library.domain.Applied;
+import com.muczynski.library.service.AppliedService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/apply")
+public class AppliedController {
+
+    @Autowired
+    private AppliedService appliedService;
+
+    @GetMapping("/apply-for-card.html")
+    public String applyForCard(Model model) {
+        model.addAttribute("applied", new Applied());
+        return "apply-for-card";
+    }
+
+    @PostMapping
+    public String applyForCard(@ModelAttribute Applied applied) {
+        appliedService.createApplied(applied);
+        return "redirect:/";
+    }
+
+    @GetMapping("/api")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    @ResponseBody
+    public ResponseEntity<List<Applied>> getAllApplied() {
+        List<Applied> applied = appliedService.getAllApplied();
+        return ResponseEntity.ok(applied);
+    }
+
+    @PostMapping("/api")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    @ResponseBody
+    public ResponseEntity<Applied> createApplied(@RequestBody Applied applied) {
+        Applied createdApplied = appliedService.createApplied(applied);
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdApplied);
+    }
+
+    @PutMapping("/api/{id}")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    @ResponseBody
+    public ResponseEntity<Applied> updateApplied(@PathVariable Long id, @RequestBody Applied applied) {
+        Applied updatedApplied = appliedService.updateApplied(id, applied);
+        return ResponseEntity.ok(updatedApplied);
+    }
+
+    @DeleteMapping("/api/{id}")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    @ResponseBody
+    public ResponseEntity<Void> deleteApplied(@PathVariable Long id) {
+        appliedService.deleteApplied(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/muczynski/library/domain/Applied.java
+++ b/src/main/java/com/muczynski/library/domain/Applied.java
@@ -1,0 +1,20 @@
+package com.muczynski.library.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Table(name = "applied")
+@Getter
+@Setter
+public class Applied {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private String password;
+
+    private String status = "pending";
+}

--- a/src/main/java/com/muczynski/library/repository/AppliedRepository.java
+++ b/src/main/java/com/muczynski/library/repository/AppliedRepository.java
@@ -1,0 +1,9 @@
+package com.muczynski.library.repository;
+
+import com.muczynski.library.domain.Applied;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AppliedRepository extends JpaRepository<Applied, Long> {
+}

--- a/src/main/java/com/muczynski/library/service/AppliedService.java
+++ b/src/main/java/com/muczynski/library/service/AppliedService.java
@@ -1,0 +1,49 @@
+package com.muczynski.library.service;
+
+import com.muczynski.library.domain.Applied;
+import com.muczynski.library.repository.AppliedRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class AppliedService {
+
+    @Autowired
+    private AppliedRepository appliedRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    public List<Applied> getAllApplied() {
+        return appliedRepository.findAll();
+    }
+
+    public Applied getAppliedById(Long id) {
+        return appliedRepository.findById(id).orElse(null);
+    }
+
+    public Applied createApplied(Applied applied) {
+        applied.setPassword(passwordEncoder.encode(applied.getPassword()));
+        return appliedRepository.save(applied);
+    }
+
+    public Applied updateApplied(Long id, Applied applied) {
+        Applied existingApplied = appliedRepository.findById(id).orElseThrow(() -> new RuntimeException("Applied not found: " + id));
+        if (applied.getStatus() != null) {
+            existingApplied.setStatus(applied.getStatus());
+        }
+        return appliedRepository.save(existingApplied);
+    }
+
+    public void deleteApplied(Long id) {
+        if (!appliedRepository.existsById(id)) {
+            throw new RuntimeException("Applied not found: " + id);
+        }
+        appliedRepository.deleteById(id);
+    }
+}

--- a/src/main/resources/static/apply-for-card.html
+++ b/src/main/resources/static/apply-for-card.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Apply for a Library Card</title>
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<div class="container">
+    <h1>Apply for a Library Card</h1>
+    <form action="/apply" method="post">
+        <div class="form-group">
+            <label for="name">Name</label>
+            <input type="text" id="name" name="name" class="form-control" required>
+        </div>
+        <div class="form-group">
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" class="form-control" required>
+        </div>
+        <button type="submit" class="btn btn-primary">Apply</button>
+    </form>
+
+    <div id="librarian-section" style="display: none;">
+        <h2>Applications</h2>
+        <table class="table">
+            <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
+            </thead>
+            <tbody id="applications-table">
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<script src="/js/apply-for-card.js"></script>
+</body>
+</html>

--- a/src/main/resources/static/js/apply-for-card.js
+++ b/src/main/resources/static/js/apply-for-card.js
@@ -1,0 +1,60 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const applicationsTable = document.getElementById('applications-table');
+    const librarianSection = document.getElementById('librarian-section');
+
+    fetch('/api/users/me')
+        .then(response => response.json())
+        .then(user => {
+            if (user.roles.includes('LIBRARIAN')) {
+                librarianSection.style.display = 'block';
+                fetch('/apply/api')
+                    .then(response => response.json())
+                    .then(data => {
+                        data.forEach(application => {
+                            const row = document.createElement('tr');
+                            row.innerHTML = `
+                                <td>${application.id}</td>
+                                <td>${application.name}</td>
+                                <td>
+                                    <select data-id="${application.id}" class="status-select">
+                                        <option value="pending" ${application.status === 'pending' ? 'selected' : ''}>Pending</option>
+                                        <option value="approved" ${application.status === 'approved' ? 'selected' : ''}>Approved</option>
+                                        <option value="not-approved" ${application.status === 'not-approved' ? 'selected' : ''}>Not Approved</option>
+                                        <option value="question" ${application.status === 'question' ? 'selected' : ''}>Question</option>
+                                    </select>
+                                </td>
+                                <td>
+                                    <button data-id="${application.id}" class="btn btn-danger delete-btn">Delete</button>
+                                </td>
+                            `;
+                            applicationsTable.appendChild(row);
+                        });
+                    });
+            }
+        });
+
+    applicationsTable.addEventListener('change', function (event) {
+        if (event.target.classList.contains('status-select')) {
+            const id = event.target.dataset.id;
+            const status = event.target.value;
+            fetch(`/apply/api/${id}`, {
+                method: 'PUT',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ status })
+            });
+        }
+    });
+
+    applicationsTable.addEventListener('click', function (event) {
+        if (event.target.classList.contains('delete-btn')) {
+            const id = event.target.dataset.id;
+            fetch(`/apply/api/${id}`, {
+                method: 'DELETE'
+            }).then(() => {
+                event.target.closest('tr').remove();
+            });
+        }
+    });
+});


### PR DESCRIPTION
Adds a new system for users to apply for a library card and for librarians to manage these applications.

- Creates an `Applied` entity to store application data, including name, hashed password, and status.
- Introduces an `/apply-for-card.html` page with a form for new applicants.
- Implements a new `AppliedController` with REST endpoints to handle application submissions and management.
- Provides a management view on the application page, visible only to users with the 'LIBRARIAN' role, allowing them to view, update the status of, and delete applications.
- Updates `SecurityConfig` to allow public access to the application form while securing the management API for librarians.
- Ensures applicant passwords are securely hashed using `BCryptPasswordEncoder` before being persisted.