### PR TITLE
feat: Add checkbox to filter returned loans

### DIFF
--- a/src/main/java/com/muczynski/library/controller/LoanController.java
+++ b/src/main/java/com/muczynski/library/controller/LoanController.java
@@ -33,8 +33,8 @@ public class LoanController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<List<LoanDto>> getAllLoans() {
-        List<LoanDto> loans = loanService.getAllLoans();
+    public ResponseEntity<List<LoanDto>> getAllLoans(@RequestParam(defaultValue = "false") boolean showAll) {
+        List<LoanDto> loans = loanService.getAllLoans(showAll);
         return ResponseEntity.ok(loans);
     }
 

--- a/src/main/java/com/muczynski/library/repository/LoanRepository.java
+++ b/src/main/java/com/muczynski/library/repository/LoanRepository.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Repository
 public interface LoanRepository extends JpaRepository<Loan, Long> {
     void deleteByLoanDate(LocalDate loanDate);
+    List<Loan> findAllByReturnDateIsNullOrderByDueDateAsc();
     List<Loan> findAllByOrderByDueDateAsc();
     long countByBookId(Long bookId);
 }

--- a/src/main/java/com/muczynski/library/service/LoanService.java
+++ b/src/main/java/com/muczynski/library/service/LoanService.java
@@ -55,8 +55,14 @@ public class LoanService {
         return null;
     }
 
-    public List<LoanDto> getAllLoans() {
-        return loanRepository.findAllByOrderByDueDateAsc().stream()
+    public List<LoanDto> getAllLoans(boolean showAll) {
+        List<Loan> loans;
+        if (showAll) {
+            loans = loanRepository.findAllByOrderByDueDateAsc();
+        } else {
+            loans = loanRepository.findAllByReturnDateIsNullOrderByDueDateAsc();
+        }
+        return loans.stream()
                 .map(loanMapper::toDto)
                 .collect(Collectors.toList());
     }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -276,6 +276,12 @@
 
         <div id="loans-section" class="section librarian-only" data-test="loans-section">
             <h2 data-test="loans-header">Loans</h2>
+            <div class="form-check mb-3">
+                <input class="form-check-input" type="checkbox" value="" id="show-returned-loans" onchange="loadLoans()" data-test="show-returned-loans-checkbox">
+                <label class="form-check-label" for="show-returned-loans">
+                    Show returned loans
+                </label>
+            </div>
             <table class="table" data-test="loan-table">
                 <thead>
                     <tr>

--- a/src/main/resources/static/js/loans.js
+++ b/src/main/resources/static/js/loans.js
@@ -1,6 +1,7 @@
 async function loadLoans() {
     try {
-        const loans = await fetchData('/api/loans');
+        const showAll = document.getElementById('show-returned-loans').checked;
+        const loans = await fetchData(`/api/loans?showAll=${showAll}`);
         const list = document.getElementById('loan-list-body');
         list.innerHTML = '';
 

--- a/src/test/java/com/muczynski/library/controller/LoanControllerTest.java
+++ b/src/test/java/com/muczynski/library/controller/LoanControllerTest.java
@@ -72,9 +72,14 @@ class LoanControllerTest {
         LoanDto dto = new LoanDto();
         dto.setId(1L);
         dto.setBookId(1L);
-        when(loanService.getAllLoans()).thenReturn(Collections.singletonList(dto));
+        when(loanService.getAllLoans(false)).thenReturn(Collections.singletonList(dto));
 
         mockMvc.perform(get("/api/loans"))
+                .andExpect(status().isOk());
+
+        when(loanService.getAllLoans(true)).thenReturn(Collections.singletonList(dto));
+
+        mockMvc.perform(get("/api/loans?showAll=true"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/muczynski/library/ui/LoansUITest.java
+++ b/src/test/java/com/muczynski/library/ui/LoansUITest.java
@@ -142,6 +142,10 @@ public class LoansUITest {
             // Return the initial loan
             initialLoanList.first().locator("[data-test='return-book-btn']").click();
             page.waitForSelector("[data-test='return-book-btn']", new Page.WaitForSelectorOptions().setState(WaitForSelectorState.DETACHED));
+
+            // Show returned loans to verify the change
+            page.check("[data-test='show-returned-loans-checkbox']");
+
             initialLoanList = page.locator("[data-test='loan-item']");
             String returnedDate = initialLoanList.first().locator("[data-test='loan-return-date']").innerText();
             assertFalse(returnedDate.isEmpty());


### PR DESCRIPTION
Add a checkbox to the Loans webpage to select whether to show or not show returned items. Default it so that it doesn't show returned items.

- Updated `LoanRepository` to add a method to fetch only active loans.
- Updated `LoanService` to accept a `showAll` boolean parameter.
- Updated `LoanController` to accept a `showAll` request parameter.
- Updated `index.html` to add a checkbox to the loans section.
- Updated `loans.js` to handle the checkbox state and modify the API call.
- Updated tests to account for the new functionality.