### PR TITLE
feat: Restrict menu items to LIBRARIAN role

### DIFF
--- a/jules-scratch/verification/verify_menu_visibility.py
+++ b/jules-scratch/verification/verify_menu_visibility.py
@@ -1,0 +1,51 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # --- Verification for Non-Librarian User ---
+    page.goto("http://localhost:8080")
+    page.click("[data-test='menu-login']")
+    page.fill("[data-test='login-username']", "user")
+    page.fill("[data-test='login-password']", "password")
+    page.click("[data-test='login-submit']")
+    page.pause()
+    page.wait_for_selector("[data-test='search-section']", state='visible')
+
+    # Check that librarian-only menu items are not visible
+    expect(page.locator("[data-test='menu-libraries']")).not_to_be_visible()
+    expect(page.locator("[data-test='menu-authors']")).not_to_be_visible()
+    expect(page.locator("[data-test='menu-books']")).not_to_be_visible()
+    expect(page.locator("[data-test='menu-users']")).not_to_be_visible()
+    expect(page.locator("[data-test='menu-loans']")).not_to_be_visible()
+    expect(page.locator("[data-test='menu-test-data']")).not_to_be_visible()
+
+    page.screenshot(path="jules-scratch/verification/non_librarian_view.png")
+
+    # --- Logout and Verification for Librarian User ---
+    page.click("[data-test='menu-logout']")
+    page.wait_for_selector("[data-test='menu-login']")
+
+    page.click("[data-test='menu-login']")
+    page.fill("[data-test='login-username']", "librarian")
+    page.fill("[data-test='login-password']", "password")
+    page.click("[data-test='login-submit']")
+    page.wait_for_selector("[data-test='loans-section']", state='visible')
+
+    # Check that librarian-only menu items are visible
+    expect(page.locator("[data-test='menu-libraries']")).to_be_visible()
+    expect(page.locator("[data-test='menu-authors']")).to_be_visible()
+    expect(page.locator("[data-test='menu-books']")).to_be_visible()
+    expect(page.locator("[data-test='menu-users']")).to_be_visible()
+    expect(page.locator("[data-test='menu-loans']")).to_be_visible()
+    expect(page.locator("[data-test='menu-test-data-item']")).to_be_visible()
+
+    page.screenshot(path="jules-scratch/verification/librarian_view.png")
+
+    context.close()
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -15,13 +15,13 @@
         <a class="navbar-brand" href="#" id="page-title">Library Management</a>
         <div id="navbarNav">
             <ul class="navbar-nav me-auto mb-2 mb-lg-0" id="section-menu" style="display: none;" data-test="section-menu">
-                <li class="nav-item">
+                <li class="nav-item librarian-only">
                     <button class="nav-link" onclick="showSection('libraries', event)" data-test="menu-libraries">Libraries</button>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item librarian-only">
                     <button class="nav-link" onclick="showSection('authors', event)" data-test="menu-authors">Authors</button>
                 </li>
-                <li class="nav-item">
+                <li class="nav-item librarian-only">
                     <button class="nav-link" onclick="showSection('books', event)" data-test="menu-books">Books</button>
                 </li>
                 <li class="nav-item librarian-only">

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -136,12 +136,9 @@ function showMainContent(roles) {
     document.getElementById('login-form').style.display = 'none';
     document.getElementById('main-content').style.display = 'block';
     document.getElementById('section-menu').style.display = 'flex';
-    // Ensure all menu items are visible for logged-in users
-    document.querySelectorAll('#section-menu li').forEach(item => {
-        item.style.display = 'list-item';
-    });
     document.getElementById('login-menu-btn').style.display = 'none';
     document.getElementById('logout-menu-btn').style.display = 'block';
+
     const errorEl = document.getElementById('login-error');
     if (errorEl) {
         errorEl.style.display = 'none';
@@ -150,21 +147,22 @@ function showMainContent(roles) {
     if (isLibrarian) {
         document.body.classList.add('user-is-librarian');
         showSection('loans');
-    } else {
-        document.body.classList.remove('user-is-librarian');
-        showSection('books');
-    }
-
-    loadLibraries();
-    loadAuthors();
-    loadBooks();
-    loadSettings();
-    if (isLibrarian) {
+        loadLibraries();
+        loadAuthors();
+        loadBooks();
         loadUsers();
         loadLoans();
         populateBookDropdowns();
         populateLoanDropdowns();
+    } else {
+        document.body.classList.remove('user-is-librarian');
+        // Hide librarian-only sections and menu items
+        document.querySelectorAll('.librarian-only').forEach(item => {
+            item.style.display = 'none';
+        });
+        showSection('search');
     }
+    loadSettings();
 }
 
 function showSection(sectionId, event) {

--- a/src/test/java/com/muczynski/library/ui/LibrariesUITest.java
+++ b/src/test/java/com/muczynski/library/ui/LibrariesUITest.java
@@ -135,13 +135,17 @@ public class LibrariesUITest {
 
             // Update
             libraryItem.first().locator("[data-test='edit-library-btn']").click();
+
+            // Wait for the form to be in update mode
+            Locator addButton = page.locator("[data-test='add-library-btn']");
+            assertThat(addButton).hasText("Update Library", new LocatorAssertions.HasTextOptions().setTimeout(5000));
+
             String updatedName = "Updated Library " + UUID.randomUUID().toString().substring(0, 8);
             System.out.println("Updating library to: " + updatedName);
             page.fill("[data-test='new-library-name']", updatedName);
             page.click("[data-test='add-library-btn']");
 
             // Wait for button to reset to "Add Library", confirming the update operation completed successfully
-            Locator addButton = page.locator("[data-test='add-library-btn']");
             assertThat(addButton).hasText("Add Library", new LocatorAssertions.HasTextOptions().setTimeout(5000));
             System.out.println("Update button reset to 'Add Library'");
 

--- a/src/test/java/com/muczynski/library/ui/UsersUITest.java
+++ b/src/test/java/com/muczynski/library/ui/UsersUITest.java
@@ -139,6 +139,11 @@ public class UsersUITest {
 
             // Update
             userItem.first().locator("[data-test='edit-user-btn']").click();
+
+            // Wait for the form to be in update mode
+            Locator addButton = page.locator("[data-test='add-user-btn']");
+            assertThat(addButton).hasText("Update User", new LocatorAssertions.HasTextOptions().setTimeout(5000));
+
             String updatedUsername = "updateduser" + UUID.randomUUID().toString().substring(0, 8);
             page.fill("[data-test='new-user-username']", updatedUsername);
             page.fill("[data-test='new-user-password']", "newpassword123");
@@ -146,7 +151,6 @@ public class UsersUITest {
             page.click("[data-test='add-user-btn']");
 
             // Wait for button to reset to "Add User", confirming the update operation completed successfully
-            Locator addButton = page.locator("[data-test='add-user-btn']");
             assertThat(addButton).hasText("Add User", new LocatorAssertions.HasTextOptions().setTimeout(5000));
 
             // Wait for the updated item to appear (confirms reload)


### PR DESCRIPTION
This commit restricts the visibility of the "Libraries", "Authors", "Books", "Users", "Loans", and "Test Data" menu items to users with the LIBRARIAN role.

- Added the `librarian-only` class to the relevant menu items in `index.html`.
- Updated `app.js` to hide elements with the `librarian-only` class for non-librarian users.
- Changed the default section for non-librarians to "Search".
- Fixed race conditions in the UI tests by adding explicit waits.