### PR TITLE
feat: Add Applied table and CRUD operations

### DIFF
--- a/src/main/java/com/muczynski/library/domain/Applied.java
+++ b/src/main/java/com/muczynski/library/domain/Applied.java
@@ -1,14 +1,25 @@
 package com.muczynski.library.domain;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Table(name = "applied")
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Applied {
+
+    public enum ApplicationStatus {
+        PENDING,
+        APPROVED,
+        NOT_APPROVED,
+        QUESTION
+    }
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -16,5 +27,7 @@ public class Applied {
     private String name;
     private String password;
 
-    private String status = "pending";
+    @Enumerated(EnumType.STRING)
+    @Column(columnDefinition = "varchar(255) default 'PENDING'")
+    private ApplicationStatus status = ApplicationStatus.PENDING;
 }

--- a/src/main/java/com/muczynski/library/dto/AppliedDto.java
+++ b/src/main/java/com/muczynski/library/dto/AppliedDto.java
@@ -1,0 +1,17 @@
+package com.muczynski.library.dto;
+
+import com.muczynski.library.domain.Applied;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppliedDto {
+    private Long id;
+    private String name;
+    private Applied.ApplicationStatus status;
+}

--- a/src/main/java/com/muczynski/library/mapper/AppliedMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/AppliedMapper.java
@@ -1,0 +1,15 @@
+package com.muczynski.library.mapper;
+
+import com.muczynski.library.domain.Applied;
+import com.muczynski.library.dto.AppliedDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface AppliedMapper {
+
+    AppliedDto appliedToAppliedDto(Applied applied);
+
+    @Mapping(target = "password", ignore = true)
+    Applied appliedDtoToApplied(AppliedDto appliedDto);
+}


### PR DESCRIPTION
Adds a new `Applied` entity to the database with columns for name, password, and status. The status defaults to 'PENDING' and can be 'APPROVED', 'NOT_APPROVED', or 'QUESTION'.

Implements backend CRUD operations with the following endpoints:
- `GET /apply/api`: Get all applications (LIBRARIAN only)
- `POST /apply/api`: Create a new application (LIBRARIAN only)
- `PUT /apply/api/{id}`: Update an application's status (LIBRARIAN only)
- `DELETE /apply/api/{id}`: Delete an application (LIBRARIAN only)
- `POST /apply`: Create a new application from the public facing `apply-for-card.html` page.

The password is encrypted before being saved to the database. Security is configured to allow public access to the application form and restrict API access to librarians.