### PR TITLE
feat: Add CRUD operations for user settings

### DIFF
--- a/src/main/java/com/muczynski/library/config/SecurityConfig.java
+++ b/src/main/java/com/muczynski/library/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/test-data/generate").hasAuthority("LIBRARIAN")
                         .requestMatchers("/apply/api/**").hasAuthority("LIBRARIAN")
+                        .requestMatchers("/api/user-settings").authenticated()
                         .requestMatchers("/api/search/**").permitAll()
                         .requestMatchers("/api/auth/**", "/login", "/css/**", "/js/**", "/", "/index.html", "/favicon.ico", "/apply-for-card.html", "/apply").permitAll()
                         .anyRequest().authenticated()

--- a/src/main/java/com/muczynski/library/controller/UserSettingsController.java
+++ b/src/main/java/com/muczynski/library/controller/UserSettingsController.java
@@ -1,0 +1,36 @@
+package com.muczynski.library.controller;
+
+import com.muczynski.library.dto.UserDto;
+import com.muczynski.library.dto.UserSettingsDto;
+import com.muczynski.library.service.UserSettingsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user-settings")
+public class UserSettingsController {
+
+    @Autowired
+    private UserSettingsService userSettingsService;
+
+    @GetMapping
+    public ResponseEntity<UserDto> getUserSettings(@AuthenticationPrincipal UserDetails userDetails) {
+        UserDto userDto = userSettingsService.getUserSettings(userDetails.getUsername());
+        return ResponseEntity.ok(userDto);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateUserSettings(@AuthenticationPrincipal UserDetails userDetails, @RequestBody UserSettingsDto userSettingsDto) {
+        userSettingsService.updateUserSettings(userDetails.getUsername(), userSettingsDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetails userDetails) {
+        userSettingsService.deleteUser(userDetails.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/muczynski/library/dto/UserSettingsDto.java
+++ b/src/main/java/com/muczynski/library/dto/UserSettingsDto.java
@@ -1,0 +1,12 @@
+package com.muczynski.library.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSettingsDto {
+    private String username;
+    private String password;
+    private String xaiApiKey;
+}

--- a/src/main/java/com/muczynski/library/service/UserSettingsService.java
+++ b/src/main/java/com/muczynski/library/service/UserSettingsService.java
@@ -1,0 +1,60 @@
+package com.muczynski.library.service;
+
+import com.muczynski.library.domain.User;
+import com.muczynski.library.dto.UserDto;
+import com.muczynski.library.dto.UserSettingsDto;
+import com.muczynski.library.mapper.UserMapper;
+import com.muczynski.library.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional
+public class UserSettingsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserMapper userMapper;
+
+    public UserDto getUserSettings(String currentUsername) {
+        User user = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return userMapper.toDto(user);
+    }
+
+    public void updateUserSettings(String currentUsername, UserSettingsDto userSettingsDto) {
+        User user = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+
+        if (StringUtils.hasText(userSettingsDto.getUsername()) && !userSettingsDto.getUsername().equals(user.getUsername())) {
+            if (userRepository.findByUsername(userSettingsDto.getUsername()).isPresent()) {
+                throw new RuntimeException("Username already taken");
+            }
+            user.setUsername(userSettingsDto.getUsername());
+        }
+
+        if (StringUtils.hasText(userSettingsDto.getPassword())) {
+            user.setPassword(passwordEncoder.encode(userSettingsDto.getPassword()));
+        }
+
+        if (StringUtils.hasText(userSettingsDto.getXaiApiKey())) {
+            user.setXaiApiKey(userSettingsDto.getXaiApiKey());
+        }
+
+        userRepository.save(user);
+    }
+
+    public void deleteUser(String currentUsername) {
+        User user = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        userRepository.delete(user);
+    }
+}


### PR DESCRIPTION
This commit introduces CRUD operations for user settings, allowing users to manage their own account details.

A new `UserSettingsController` is added with the following endpoints:
- `GET /api/user-settings`: Retrieves the current user's settings.
- `PUT /api/user-settings`: Updates the current user's username, password, and XAI API key.
- `DELETE /api/user-settings`: Deletes the current user's account.

A `UserSettingsService` is implemented to handle the business logic, and a `UserSettingsDto` is used for data transfer. The new endpoints are secured to ensure that only authenticated users can access them.