### PR TITLE
feat: Implement librarian view for library card applications

### DIFF
--- a/jules-scratch/verification/verify_applications_section.py
+++ b/jules-scratch/verification/verify_applications_section.py
@@ -1,0 +1,46 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Go to the login page
+    page.goto("http://localhost:8080")
+
+    # Go to the login page
+    page.goto("http://localhost:8080")
+
+    # Go to the login page
+    page.goto("http://localhost:8080")
+
+    # Go to the login page
+    page.goto("http://localhost:8080")
+
+    # Give the page some time to load
+    page.wait_for_timeout(5000)
+
+    # Show the login form
+    page.evaluate("showLoginForm()")
+
+    # Log in as librarian
+    page.get_by_test_id("login-username").fill("librarian")
+    page.get_by_test_id("login-password").fill("password")
+    page.get_by_test_id("login-submit").click()
+
+    # Wait for the main content to load
+    expect(page.get_by_test_id("main-content")).to_be_visible()
+
+    # Navigate to the "Applications" section
+    page.get_by_test_id("menu-applied").click()
+
+    # Wait for the applications table to be visible
+    expect(page.get_by_test_id("applied-table")).to_be_visible()
+
+    # Take a screenshot
+    page.screenshot(path="jules-scratch/verification/applications_section.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/java/com/muczynski/library/controller/AppliedController.java
+++ b/src/main/java/com/muczynski/library/controller/AppliedController.java
@@ -19,7 +19,7 @@ import org.springframework.ui.Model;
 
 import java.util.List;
 
-@Controller
+@RestController
 @RequestMapping("/api")
 public class AppliedController {
 
@@ -35,33 +35,29 @@ public class AppliedController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/apply/api")
+    @GetMapping("/applied")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    @ResponseBody
     public ResponseEntity<List<Applied>> getAllApplied() {
         List<Applied> applied = appliedService.getAllApplied();
         return ResponseEntity.ok(applied);
     }
 
-    @PostMapping("/api")
+    @PostMapping("/applied")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    @ResponseBody
     public ResponseEntity<Applied> createApplied(@RequestBody Applied applied) {
         Applied createdApplied = appliedService.createApplied(applied);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdApplied);
     }
 
-    @PutMapping("/api/{id}")
+    @PutMapping("/applied/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    @ResponseBody
     public ResponseEntity<Applied> updateApplied(@PathVariable Long id, @RequestBody Applied applied) {
         Applied updatedApplied = appliedService.updateApplied(id, applied);
         return ResponseEntity.ok(updatedApplied);
     }
 
-    @DeleteMapping("/api/{id}")
+    @DeleteMapping("/applied/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    @ResponseBody
     public ResponseEntity<Void> deleteApplied(@PathVariable Long id) {
         appliedService.deleteApplied(id);
         return ResponseEntity.noContent().build();

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -40,6 +40,9 @@
                     <button class="nav-link" onclick="showSection('users', event)" data-test="menu-users">Users</button>
                 </li>
                 <li class="nav-item librarian-only">
+                    <button class="nav-link" onclick="showSection('applied', event)" data-test="menu-applied">Applications</button>
+                </li>
+                <li class="nav-item librarian-only">
                     <button class="nav-link" onclick="showSection('loans', event)" data-test="menu-loans">Loans</button>
                 </li>
                 <li class="nav-item librarian-only" data-test="menu-test-data-item">
@@ -245,6 +248,28 @@
             <div id="apply-success" class="alert alert-success mt-3" style="display: none;" data-test="apply-success"></div>
         </div>
 
+        <div id="applied-section" class="section librarian-only" data-test="applied-section">
+            <h2 data-test="applied-header">Applications</h2>
+            <table class="table" data-test="applied-table">
+                <thead>
+                <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Actions</th>
+                </tr>
+                </thead>
+                <tbody id="applied-list-body" data-test="applied-list-body">
+                </tbody>
+            </table>
+            <div data-test="applied-form">
+                <div class="mb-3">
+                    <label for="new-applied-name" class="form-label">Name:</label>
+                    <input type="text" id="new-applied-name" class="form-control" placeholder="Name" autocomplete="name" data-test="new-applied-name">
+                </div>
+                <button id="add-applied-btn" type="button" class="btn btn-primary" onclick="addApplied()" data-test="add-applied-btn">Add Application</button>
+            </div>
+        </div>
+
         <div id="users-section" class="section librarian-only" data-test="users-section">
             <h2 data-test="users-header">Users</h2>
             <table class="table" data-test="user-table">
@@ -355,6 +380,7 @@
 <script src="js/books.js"></script>
 <script src="js/users.js"></script>
 <script src="js/loans.js"></script>
+<script src="js/applied.js"></script>
 <script src="js/search.js"></script>
 <script src="js/settings.js"></script>
 <script src="js/test-data.js"></script>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -152,6 +152,7 @@ function showMainContent(roles) {
         loadBooks();
         loadUsers();
         loadLoans();
+        loadApplied();
         populateBookDropdowns();
         populateLoanDropdowns();
     } else {
@@ -185,6 +186,9 @@ function showSection(sectionId, event) {
 
     if (sectionId === 'test-data') {
         loadTestDataStats();
+    }
+    if (sectionId === 'applied') {
+        loadApplied();
     }
     if (sectionId === 'settings') {
         loadUsers();

--- a/src/main/resources/static/js/applied.js
+++ b/src/main/resources/static/js/applied.js
@@ -1,0 +1,69 @@
+async function loadApplied() {
+    if (!isLibrarian) return;
+    try {
+        const applications = await fetchData('/api/applied');
+        const appliedListBody = document.getElementById('applied-list-body');
+        appliedListBody.innerHTML = '';
+        applications.forEach(app => {
+            const row = document.createElement('tr');
+            row.innerHTML = `
+                <td>${app.name}</td>
+                <td>
+                    <select class="form-select" onchange="updateAppliedStatus(${app.id}, this.value)">
+                        <option value="PENDING" ${app.status === 'PENDING' ? 'selected' : ''}>Pending</option>
+                        <option value="APPROVED" ${app.status === 'APPROVED' ? 'selected' : ''}>Approved</option>
+                        <option value="NOT_APPROVED" ${app.status === 'NOT_APPROVED' ? 'selected' : ''}>Not Approved</option>
+                        <option value="QUESTION" ${app.status === 'QUESTION' ? 'selected' : ''}>Question</option>
+                    </select>
+                </td>
+                <td>
+                    <button class="btn btn-danger btn-sm" onclick="deleteApplied(${app.id})">Delete</button>
+                </td>
+            `;
+            appliedListBody.appendChild(row);
+        });
+    } catch (error) {
+        console.error('Failed to load applications:', error);
+        showError('applied', 'Failed to load applications.');
+    }
+}
+
+async function addApplied() {
+    const name = document.getElementById('new-applied-name').value.trim();
+    if (!name) {
+        showError('applied', 'Please enter a name.');
+        return;
+    }
+    try {
+        await postData('/api/applied', { name });
+        document.getElementById('new-applied-name').value = '';
+        clearError('applied');
+        loadApplied();
+    } catch (error) {
+        console.error('Failed to add application:', error);
+        showError('applied', 'Failed to add application.');
+    }
+}
+
+async function updateAppliedStatus(id, status) {
+    try {
+        await putData(`/api/applied/${id}`, { status });
+        loadApplied();
+    } catch (error) {
+        console.error(`Failed to update application ${id}:`, error);
+        showError('applied', `Failed to update application ${id}.`);
+    }
+}
+
+async function deleteApplied(id) {
+    if (!confirm('Are you sure you want to delete this application?')) {
+        return;
+    }
+    try {
+        await deleteData(`/api/applied/${id}`);
+        loadApplied();
+    } catch (error) {
+        console.error(`Failed to delete application ${id}:`, error);
+        showError('applied', `Failed to delete application ${id}.`);
+    }
+}


### PR DESCRIPTION
This commit introduces a new feature for librarians to view and manage library card applications.

- Adds a new 'Applications' section to the UI, visible only to users with the 'LIBRARIAN' role.
- The new section displays a table of all card applications from the 'Applied' database table.
- Implements full CRUD functionality for applications, allowing librarians to create, read, update (status), and delete applications.
- Refactors the `AppliedController` to use a more consistent and RESTful endpoint structure under `/api/applied`.
- Creates a new `applied.js` file to handle the frontend logic for the new section.
- Integrates the new section into the main application flow in `app.js`.