### PR TITLE
feat: Add Photo button in the Book editor

### DIFF
--- a/jules-scratch/verification/verify_photo_upload.py
+++ b/jules-scratch/verification/verify_photo_upload.py
@@ -1,0 +1,29 @@
+import re
+from playwright.sync_api import Page, expect
+
+def test_add_photo_to_book(page: Page):
+    # 1. Arrange: Go to the application and log in.
+    page.goto("http://localhost:8080")
+    page.get_by_test_id("menu-login").click()
+    page.get_by_test_id("login-username").fill("librarian")
+    page.get_by_test_id("login-password").fill("password")
+    page.get_by_test_id("login-submit").click()
+
+    # 2. Act: Navigate to the books section and edit a book.
+    page.get_by_test_id("menu-books").click()
+    page.get_by_test_id("book-item").first.get_by_test_id("edit-book-btn").click()
+
+    # 3. Assert: Check that the "Add Photo" button is visible.
+    expect(page.get_by_test_id("add-photo-btn")).to_be_visible()
+
+    # 4. Act: Upload a photo.
+    with page.expect_file_chooser() as fc_info:
+        page.get_by_test_id("add-photo-btn").click()
+    file_chooser = fc_info.value
+    file_chooser.set_files("src/test/resources/test-image.png")
+
+    # 5. Assert: Check that the photo is displayed.
+    expect(page.get_by_test_id("book-photo")).to_be_visible()
+
+    # 6. Screenshot: Capture the final result for visual verification.
+    page.screenshot(path="verification.png")

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -208,8 +208,9 @@
                     <label for="book-library" class="form-label">Library:</label>
                     <select id="book-library" class="form-select" data-test="book-library"></select>
                 </div>
+                <input type="hidden" id="current-book-id">
                 <button id="add-book-btn" class="btn btn-primary mb-3" onclick="addBook()" data-test="add-book-btn">Add Book</button>
-                <button id="add-photo-btn" class="btn btn-secondary mb-3" onclick="addPhoto()" data-test="add-photo-btn">Add Photo</button>
+                <button id="add-photo-btn" class="btn btn-secondary mb-3" onclick="addPhoto()" data-test="add-photo-btn" style="display: none;">Add Photo</button>
                 <input type="file" id="photo-upload" style="display: none;" accept="image/*" capture="environment"/>
                 <h3 data-test="bulk-books-header">Bulk Import Books</h3>
                 <div class="input-group mb-3">

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -166,6 +166,11 @@ function showMainContent(roles) {
 }
 
 function showSection(sectionId, event) {
+    const currentActiveButton = document.querySelector('#section-menu button.active');
+    if (currentActiveButton && currentActiveButton.textContent === 'Books' && sectionId !== 'books') {
+        resetBookForm();
+    }
+
     // If not logged in and showing a section, hide welcome/login and show main content
     if (!isLibrarian && (document.getElementById('welcome-screen').style.display === 'block' || document.getElementById('login-form').style.display === 'block')) {
         document.getElementById('welcome-screen').style.display = 'none';


### PR DESCRIPTION
This commit introduces an "Add Photo" button to the book editor, allowing users to upload photos for books.

The following changes were made:
- Added a hidden input field to the book form to store the ID of the book being edited.
- The "Add Photo" button is now only visible when editing a book.
- The book form is reset when navigating away from the books section.
- The photo upload logic now uses the hidden input field to get the book's ID.