### PR TITLE
feat: Implement application approval

### DIFF
--- a/jules-scratch/verification/verify_approval.py
+++ b/jules-scratch/verification/verify_approval.py
@@ -1,0 +1,48 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        # Apply for a card first
+        page.goto("http://localhost:8080/apply-for-card.html")
+        page.get_by_label("Name").fill("testuser")
+        page.get_by_label("Password").fill("password")
+        page.get_by_role("button", name="Apply").click()
+        expect(page.get_by_text("Library card application successful!")).to_be_visible()
+
+        # Log in as librarian
+        page.goto("http://localhost:8080")
+        page.get_by_role("button", name="Login").click()
+        page.locator('[data-test="login-username"]').fill("librarian")
+        page.locator('[data-test="login-password"]').fill("password")
+
+        # Click the login button and wait for the navigation to complete
+        with page.expect_navigation():
+            page.locator('[data-test="login-form"] button[type="submit"]').click()
+
+        # Wait for main content to be visible
+        expect(page.locator('[data-test="main-content"]')).to_be_visible()
+
+        # Go to applications page
+        page.get_by_role("button", name="Applied").click()
+
+        # Find the row for the new user and approve
+        row = page.get_by_role("row", name=re.compile("testuser"))
+
+        page.on("dialog", lambda dialog: dialog.accept())
+        row.get_by_role("button", name="✔️").click()
+
+
+        # Verify the status is approved
+        expect(row.get_by_role("option", name="Approved")).to_be_selected()
+
+        page.screenshot(path="jules-scratch/verification/verification.png")
+    finally:
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/java/com/muczynski/library/controller/AppliedController.java
+++ b/src/main/java/com/muczynski/library/controller/AppliedController.java
@@ -62,4 +62,11 @@ public class AppliedController {
         appliedService.deleteApplied(id);
         return ResponseEntity.noContent().build();
     }
+
+    @PostMapping("/applied/{id}/approve")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<Void> approveApplication(@PathVariable Long id) {
+        appliedService.approveApplication(id);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/resources/static/js/applied.js
+++ b/src/main/resources/static/js/applied.js
@@ -33,7 +33,13 @@ async function approveApplication(id) {
     if (!confirm('Are you sure you want to approve this application?')) {
         return;
     }
-    await updateAppliedStatus(id, 'APPROVED');
+    try {
+        await postData(`/api/applied/${id}/approve`, {}, false, false);
+        loadApplied();
+    } catch (error) {
+        console.error(`Failed to approve application ${id}:`, error);
+        showError('applied', `Failed to approve application ${id}.`);
+    }
 }
 
 async function updateAppliedStatus(id, status) {


### PR DESCRIPTION
This change introduces the functionality for librarians to approve library card applications.

- Adds a new endpoint `/api/applied/{id}/approve` to handle the approval process.
- The `AppliedService` now has a method to create a new user with the "USER" role from the application details and update the application status to "APPROVED".
- The frontend has been updated to call this new endpoint when the approve button is clicked.