### PR TITLE
feat: Hide book list when editing a book

### DIFF
--- a/jules-scratch/verification/verify_books_view.py
+++ b/jules-scratch/verification/verify_books_view.py
@@ -1,0 +1,47 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Log in as librarian
+    page.goto("http://localhost:8080")
+    page.wait_for_timeout(30000) # Wait for 30 seconds
+    page.get_by_test_id("menu-login").click()
+    page.get_by_test_id("login-username").fill("librarian")
+    page.get_by_test_id("login-password").fill("divinemercy")
+    page.get_by_test_id("login-submit").click()
+
+    # Go to books page
+    page.get_by_test_id("menu-books").click()
+
+    # Expect the book list to be visible and the form to be hidden
+    expect(page.get_by_test_id("book-table")).to_be_visible()
+    expect(page.get_by_test_id("books-form")).to_be_hidden()
+
+    # Click edit on the first book
+    page.get_by_test_id("edit-book-btn").first.click()
+
+    # Expect the book list to be hidden and the form to be visible
+    expect(page.get_by_test_id("book-table")).to_be_hidden()
+    expect(page.get_by_test_id("books-form")).to_be_visible()
+
+    # Take a screenshot
+    page.screenshot(path="jules-scratch/verification/edit-book-view.png")
+
+    # Click the cancel button
+    page.get_by_test_id("cancel-book-btn").click()
+
+    # Expect the book list to be visible and the form to be hidden again
+    expect(page.get_by_test_id("book-table")).to_be_visible()
+    expect(page.get_by_test_id("books-form")).to_be_hidden()
+
+    # Take a screenshot
+    page.screenshot(path="jules-scratch/verification/book-list-view.png")
+
+    context.close()
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -208,6 +208,7 @@
                 </div>
                 <input type="hidden" id="current-book-id">
                 <button id="add-book-btn" class="btn btn-primary mb-3" onclick="addBook()" data-test="add-book-btn">Add Book</button>
+                <button id="cancel-book-btn" class="btn btn-secondary mb-3" onclick="resetBookForm()" data-test="cancel-book-btn" style="display: none;">Cancel</button>
                 <button id="add-photo-btn" class="btn btn-secondary mb-3" onclick="addPhoto()" data-test="add-photo-btn" style="display: none;">Add Photo</button>
                 <input type="file" id="photo-upload" style="display: none;" accept="image/*" capture="environment"/>
             </div>

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -205,6 +205,7 @@ function showSection(sectionId, event) {
         loadLoans();
     }
     if (sectionId === 'books') {
+        resetBookForm();
         loadBooks();
     }
     if (sectionId === 'authors') {

--- a/src/main/resources/static/js/books.js
+++ b/src/main/resources/static/js/books.js
@@ -40,6 +40,11 @@ async function loadBooks() {
     }
 }
 
+function showBookList(show) {
+    document.querySelector('[data-test="book-table"]').style.display = show ? 'table' : 'none';
+    document.querySelector('[data-test="books-form"]').style.display = show ? 'none' : 'block';
+}
+
 function resetBookForm() {
     document.getElementById('new-book-title').value = '';
     document.getElementById('new-book-year').value = '';
@@ -58,7 +63,9 @@ function resetBookForm() {
     btn.onclick = addBook;
 
     document.getElementById('add-photo-btn').style.display = 'none';
+    document.getElementById('cancel-book-btn').style.display = 'none';
     document.getElementById('book-photos-container').style.display = 'none';
+    showBookList(true);
 }
 
 async function addBook() {
@@ -89,6 +96,7 @@ async function addBook() {
 }
 
 async function editBook(id) {
+    showBookList(false);
     const data = await fetchData(`/api/books/${id}`);
     document.getElementById('new-book-title').value = data.title || '';
     document.getElementById('new-book-year').value = data.publicationYear || '';
@@ -105,6 +113,7 @@ async function editBook(id) {
     btn.textContent = 'Update Book';
     btn.onclick = () => updateBook(id);
     document.getElementById('add-photo-btn').style.display = 'inline-block';
+    document.getElementById('cancel-book-btn').style.display = 'inline-block';
 
     const photos = await fetchData(`/api/books/${id}/photos`);
     displayBookPhotos(photos, id);
@@ -132,6 +141,7 @@ async function updateBook(id) {
         await loadLoans();
         await populateLoanDropdowns();
         clearError('books');
+        showBookList(true);
     } catch (error) {
         showError('books', 'Failed to update book: ' + error.message);
     }


### PR DESCRIPTION
This commit introduces a user experience improvement to the book editing process. When a user clicks the 'Edit' button for a book, the main book list is now hidden, and only the book editing form is displayed. This helps the user focus on the editing task without the distraction of the book list.

The book list is restored to view when the user:
- Clicks the new 'Cancel' button in the edit form.
- Successfully updates the book.
- Navigates away from and back to the 'Books' section.

To achieve this, the following changes were made:
- A 'Cancel' button was added to the book form in `index.html`.
- JavaScript logic in `books.js` was updated to toggle the visibility of the book list and the edit form.
- The `app.js` file was modified to ensure the book form is reset correctly when navigating to the 'Books' section.