### PR TITLE
feat: Default to search page for unauthenticated users

### DIFF
--- a/jules-scratch/verification/verify_welcome_page.py
+++ b/jules-scratch/verification/verify_welcome_page.py
@@ -1,0 +1,8 @@
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+    page.goto("http://localhost:8080")
+    page.screenshot(path="jules-scratch/verification/verification.png")
+    browser.close()

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -65,11 +65,6 @@
 </nav>
 
 <div class="container mt-4">
-    <div id="welcome-screen" data-test="welcome-screen" class="col-md-6 offset-md-3 text-center">
-        <h2 data-test="welcome-header">Welcome to the Library</h2>
-        <p>Please log in to manage the library.</p>
-    </div>
-
     <div id="login-form" data-test="login-form" class="col-md-6 offset-md-3" style="display: none;">
         <h2 data-test="login-header">Login</h2>
         <form id="login" name="login" action="/login" method="post">

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -24,8 +24,8 @@ document.addEventListener('DOMContentLoaded', () => {
     try {
         checkAuthentication();
     } catch (error) {
-        console.error('Error in initial auth check, showing welcome screen.', error);
-        showWelcomeScreen();
+        console.error('Error in initial auth check, showing search page.', error);
+        showPublicSearchPage();
     }
     // Check for login error in URL params
     const urlParams = new URLSearchParams(window.location.search);
@@ -64,19 +64,19 @@ async function checkAuthentication() {
             console.log('User authenticated:', user);
             showMainContent(user.roles);
         } else {
-            console.log('Authentication failed or non-JSON response, showing welcome screen');
-            showWelcomeScreen();
+            console.log('Authentication failed or non-JSON response, showing search page');
+            showPublicSearchPage();
         }
     } catch (error) {
         console.error('Error during authentication check:', error);
-        showWelcomeScreen();
+        showPublicSearchPage();
     }
 }
 
-function showWelcomeScreen() {
-    document.getElementById('welcome-screen').style.display = 'block';
+function showPublicSearchPage() {
     document.getElementById('login-form').style.display = 'none';
-    document.getElementById('main-content').style.display = 'none';
+    document.getElementById('main-content').style.display = 'block';
+    showSection('search');
     document.getElementById('login-menu-btn').style.display = 'block';
     document.getElementById('logout-menu-btn').style.display = 'none';
     const pageTitle = document.getElementById('page-title');
@@ -95,7 +95,6 @@ function showWelcomeScreen() {
 }
 
 function showLoginForm() {
-    document.getElementById('welcome-screen').style.display = 'none';
     document.getElementById('login-form').style.display = 'block';
     document.getElementById('main-content').style.display = 'none';
     document.getElementById('login-menu-btn').style.display = 'block';
@@ -132,7 +131,6 @@ function showLoginError() {
 function showMainContent(roles) {
     console.log('Showing main content for roles:', roles);
     isLibrarian = roles.includes('LIBRARIAN');
-    document.getElementById('welcome-screen').style.display = 'none';
     document.getElementById('login-form').style.display = 'none';
     document.getElementById('main-content').style.display = 'block';
     document.getElementById('section-menu').style.display = 'flex';
@@ -172,9 +170,8 @@ function showSection(sectionId, event) {
         resetBookForm();
     }
 
-    // If not logged in and showing a section, hide welcome/login and show main content
-    if (!isLibrarian && (document.getElementById('welcome-screen').style.display === 'block' || document.getElementById('login-form').style.display === 'block')) {
-        document.getElementById('welcome-screen').style.display = 'none';
+    // If not logged in and showing a section, hide login and show main content
+    if (!isLibrarian && (document.getElementById('login-form').style.display === 'block')) {
         document.getElementById('login-form').style.display = 'none';
         document.getElementById('main-content').style.display = 'block';
     }
@@ -254,7 +251,6 @@ function createBookByPhoto() {
 function logout() {
     document.body.classList.remove('user-is-librarian');
     fetch('/logout', { method: 'POST' }).then(() => {
-        showWelcomeScreen();
         window.location.href = '/';
     });
 }


### PR DESCRIPTION
Removes the welcome page and defaults unauthenticated users to the search page.

- Removes the welcome screen HTML from `index.html`.
- Updates `app.js` to show the search page by default for non-authenticated users.
- Creates a new `showPublicSearchPage` function to handle the new default view.
- Removes the now-unused `showWelcomeScreen` function and all references to it.