### PR TITLE
Refactor: Ensure data is refreshed on section navigation

### DIFF
--- a/jules-scratch/verification/verify_data_loading.py
+++ b/jules-scratch/verification/verify_data_loading.py
@@ -1,0 +1,45 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run_verification():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+
+        # 1. Login as librarian
+        page.goto("http://localhost:8080")
+
+        # Click the login button to reveal the form
+        page.click('button:has-text("Login")')
+
+        # Wait for the login form to be visible
+        expect(page.locator('input[name="username"]')).to_be_visible(timeout=60000)
+
+        page.fill('input[name="username"]', 'librarian')
+        page.fill('input[name="password"]', 'divinemercy')
+        page.click('button[type="submit"]')
+
+        # 2. Create test data
+        page.click('button:has-text("Test Data")')
+
+        # Wait for the "Create Test Data" button to be visible
+        create_button = page.locator('button:has-text("Create Test Data")')
+        expect(create_button).to_be_visible(timeout=60000)
+        create_button.click()
+
+        # Wait for the confirmation message
+        expect(page.locator("text=Test data created successfully")).to_be_visible()
+
+        # 3. Navigate to Loans page and verify
+        page.click('button:has-text("Loans")')
+        expect(page.locator('[data-test="loan-item"]')).not_to_be_empty(timeout=60000)
+        page.screenshot(path="jules-scratch/verification/loans-page.png")
+
+        # 4. Navigate to Users page and verify
+        page.click('button:has-text("Users")')
+        expect(page.locator('[data-test="user-item"]')).not_to_be_empty(timeout=60000)
+        page.screenshot(path="jules-scratch/verification/users-page.png")
+
+        browser.close()
+
+if __name__ == "__main__":
+    run_verification()

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -146,11 +146,6 @@ function showMainContent(roles) {
         document.body.classList.add('user-is-librarian');
         showSection('loans');
         loadLibraries();
-        loadAuthors();
-        loadBooks();
-        loadUsers();
-        loadLoans();
-        loadApplied();
         populateBookDropdowns();
         populateLoanDropdowns();
     } else {
@@ -161,7 +156,6 @@ function showMainContent(roles) {
         });
         showSection('search');
     }
-    loadSettings();
 }
 
 function showSection(sectionId, event) {
@@ -196,7 +190,7 @@ function showSection(sectionId, event) {
         loadSettings();
     }
     if (sectionId === 'users') {
-        loadSettings();
+        loadUsers();
     }
     if (sectionId === 'loans') {
         loadLoans();
@@ -208,6 +202,9 @@ function showSection(sectionId, event) {
     if (sectionId === 'authors') {
         loadAuthors();
         resetAuthorForm();
+    }
+    if (sectionId === 'applied') {
+        loadApplied();
     }
     // Update active button
     document.querySelectorAll('#section-menu button').forEach(btn => {


### PR DESCRIPTION
The previous implementation loaded data for all sections upon login, but did not refresh the data when navigating between sections. This caused stale data to be displayed.

This commit refactors the data loading logic to ensure that data is fetched from the backend every time a user navigates to a new section. This is achieved by moving the data loading functions into the `showSection` function in `app.js`.