### PR TITLE
feat: Add thumbnail endpoint for book photos

### DIFF
--- a/src/main/java/com/muczynski/library/controller/PhotoController.java
+++ b/src/main/java/com/muczynski/library/controller/PhotoController.java
@@ -3,12 +3,10 @@ package com.muczynski.library.controller;
 import com.muczynski.library.domain.Photo;
 import com.muczynski.library.service.PhotoService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.util.Pair;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/photos")
@@ -28,5 +26,16 @@ public class PhotoController {
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))
                 .body(image);
+    }
+
+    @GetMapping("/{id}/thumbnail")
+    public ResponseEntity<byte[]> getThumbnail(@PathVariable Long id, @RequestParam Integer width) {
+        Pair<byte[], String> thumbnailData = photoService.getThumbnail(id, width);
+        if (thumbnailData == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(thumbnailData.getSecond()))
+                .body(thumbnailData.getFirst());
     }
 }

--- a/src/test/java/com/muczynski/library/controller/PhotoControllerTest.java
+++ b/src/test/java/com/muczynski/library/controller/PhotoControllerTest.java
@@ -1,0 +1,80 @@
+package com.muczynski.library.controller;
+
+import com.muczynski.library.domain.Book;
+import com.muczynski.library.domain.Photo;
+import com.muczynski.library.repository.BookRepository;
+import com.muczynski.library.repository.LoanRepository;
+import com.muczynski.library.repository.PhotoRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class PhotoControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PhotoRepository photoRepository;
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private LoanRepository loanRepository;
+
+    @AfterEach
+    void tearDown() {
+        loanRepository.deleteAll();
+        photoRepository.deleteAll();
+        bookRepository.deleteAll();
+    }
+
+    private byte[] createDummyImage(int width, int height) throws Exception {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ImageIO.write(image, "jpg", baos);
+        return baos.toByteArray();
+    }
+
+    @Test
+    @WithMockUser
+    void getThumbnail() throws Exception {
+        Book book = new Book();
+        bookRepository.save(book);
+
+        Photo photo = new Photo();
+        photo.setBook(book);
+        photo.setImage(createDummyImage(200, 300));
+        photo.setContentType(MediaType.IMAGE_JPEG_VALUE);
+        photoRepository.save(photo);
+
+        MvcResult result = mockMvc.perform(get("/api/photos/" + photo.getId() + "/thumbnail?width=100"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        byte[] thumbnailBytes = result.getResponse().getContentAsByteArray();
+        BufferedImage thumbnailImage = ImageIO.read(new ByteArrayInputStream(thumbnailBytes));
+        assertEquals(100, thumbnailImage.getWidth());
+        assertEquals(150, thumbnailImage.getHeight());
+    }
+}


### PR DESCRIPTION
This commit introduces a new endpoint to provide thumbnail-resolution images for photos attached to a book.

A new GET endpoint has been added to the `PhotoController` at `/api/photos/{id}/thumbnail`. This endpoint accepts a `width` request parameter and returns a resized image while preserving the aspect ratio.

The `PhotoService` has been updated with a `getThumbnail` method that handles the image resizing logic using `java.awt.image.BufferedImage`.

An integration test has been added in `PhotoControllerTest` to verify the functionality of the new endpoint.