### PR TITLE
feat: Add progress indicator for photo uploads

### DIFF
--- a/jules-scratch/verification/test_image.jpg
+++ b/jules-scratch/verification/test_image.jpg
@@ -1,0 +1,1 @@
+dummy image data

--- a/jules-scratch/verification/verify_feature.py
+++ b/jules-scratch/verification/verify_feature.py
@@ -1,0 +1,72 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    try:
+        page.goto("http://localhost:8080")
+
+        # Click login button to reveal form
+        page.click('button[data-test="menu-login"]')
+        expect(page.locator('[data-test="login-form"]')).to_be_visible()
+
+        # Login as librarian
+        page.fill('input[name="username"]', 'librarian')
+        page.fill('input[name="password"]', 'divinemercy')
+        page.click('button[type="submit"]')
+        expect(page.locator('button[data-test="menu-logout"]')).to_be_visible()
+
+        # Navigate to books section
+        page.click('button[data-test="menu-books"]')
+        expect(page.locator('[data-test="book-table"]')).to_be_visible()
+
+        # Add a library
+        page.click('button[data-test="menu-libraries"]')
+        page.fill('input[data-test="new-library-name"]', 'Test Library')
+        page.fill('input[data-test="new-library-hostname"]', 'testhost')
+        page.click('button[data-test="add-library-btn"]')
+        expect(page.locator('[data-test="library-name"]')).to_contain_text('Test Library')
+
+        # Add an author
+        page.click('button[data-test="menu-authors"]')
+        page.fill('input[data-test="new-author-name"]', 'Test Author')
+        page.click('button[data-test="add-author-btn"]')
+        page.wait_for_timeout(1000) # wait for UI to update
+        expect(page.locator('[data-test="author-list-body"]')).to_contain_text('Test Author')
+
+        # Navigate back to books section
+        page.click('button[data-test="menu-books"]')
+
+        # Add a book to ensure one exists
+        page.fill('#new-book-title', 'Test Book')
+        page.select_option('#book-author', label='Test Author')
+        page.select_option('#book-library', label='Test Library')
+        page.click('#add-book-btn')
+        expect(page.locator('[data-test="book-item"]')).to_contain_text('Test Book')
+
+        # Click on the first book's edit button
+        page.locator('[data-test="edit-book-btn"]').first.click()
+        expect(page.locator('[data-test="books-form"]')).to_be_visible()
+
+        # Upload a photo
+        page.set_input_files('input#photo-upload', 'jules-scratch/verification/test_image.jpg')
+
+        # Check for wait cursor
+        cursor_style = page.evaluate("document.body.style.cursor")
+        print(f"Cursor style: {cursor_style}")
+        # Not a reliable way to test this in playwright, but we can check if it changed from default
+
+        # Wait for the photo to appear
+        expect(page.locator('[data-test="book-photo"]')).to_be_visible()
+
+        page.screenshot(path="jules-scratch/verification/verification.png")
+
+    finally:
+        context.close()
+        browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/resources/static/js/books.js
+++ b/src/main/resources/static/js/books.js
@@ -345,6 +345,8 @@ document.getElementById('photo-upload').addEventListener('change', async (event)
     const formData = new FormData();
     formData.append('file', file);
 
+    document.body.style.cursor = 'wait';
+
     try {
         await postData(`/api/books/${bookId}/photos`, formData, true);
         const photos = await fetchData(`/api/books/${bookId}/photos`);
@@ -358,9 +360,12 @@ document.getElementById('photo-upload').addEventListener('change', async (event)
         }
         event.target.value = '';
         clearError('books');
+        document.getElementById('book-photos-container').scrollIntoView({ behavior: 'smooth' });
     } catch (error) {
         showError('books', 'Failed to add photo: ' + error.message);
         event.target.value = '';
+    } finally {
+        document.body.style.cursor = 'default';
     }
 });
 


### PR DESCRIPTION
Adds an indefinite progress indicator on the mouse pointer when photos are uploading in the book editor.

When a photo upload is initiated, the mouse cursor is set to 'wait'. After the upload is complete, the cursor is reset to 'default', and the page is scrolled to the photo thumbnails. A `finally` block is used to ensure the cursor is always reset.