### PR TITLE
feat: Update book photo thumbnails

### DIFF
--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -95,8 +95,8 @@ html, body {
 
 .book-photo-thumbnail {
     position: relative;
-    width: 150px;
-    height: 150px;
+    width: 300px;
+    height: 300px;
     border: 1px solid #ddd;
     border-radius: 5px;
     overflow: hidden;
@@ -158,8 +158,8 @@ html, body {
     }
 
     .book-photo-thumbnail {
-        width: 200px;
-        height: 200px;
+        width: 400px;
+        height: 400px;
     }
 }
 

--- a/src/main/resources/static/js/books.js
+++ b/src/main/resources/static/js/books.js
@@ -236,7 +236,7 @@ function displayBookPhotos(photos, bookId) {
 
             const img = document.createElement('img');
             img.setAttribute('data-test', 'book-photo');
-            img.src = `/api/photos/${photo.id}/image`;
+            img.src = `/api/photos/${photo.id}/thumbnail?width=300`;
             if (photo.rotation && photo.rotation !== 0) {
                 img.style.transform = `rotate(${photo.rotation}deg)`;
             }


### PR DESCRIPTION
Use thumbnail endpoint and increase thumbnail size.

- In the book edit view, the book photo thumbnails are now fetched using the `/api/photos/{id}/thumbnail` endpoint instead of the full image endpoint.
- The size of the thumbnails has been doubled in the CSS to make them more prominent.