### PR TITLE
feat: Allow photos to be attached to authors

### DIFF
--- a/src/main/java/com/muczynski/library/controller/AuthorController.java
+++ b/src/main/java/com/muczynski/library/controller/AuthorController.java
@@ -1,12 +1,15 @@
 package com.muczynski.library.controller;
 
 import com.muczynski.library.dto.AuthorDto;
+import com.muczynski.library.dto.PhotoDto;
 import com.muczynski.library.service.AuthorService;
+import com.muczynski.library.service.PhotoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -16,6 +19,9 @@ public class AuthorController {
 
     @Autowired
     private AuthorService authorService;
+
+    @Autowired
+    private PhotoService photoService;
 
     @PostMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
@@ -57,4 +63,10 @@ public class AuthorController {
         }
     }
 
+    @PostMapping("/{id}/photos")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<PhotoDto> addPhotoToAuthor(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        PhotoDto newPhoto = photoService.addPhotoToAuthor(id, file);
+        return ResponseEntity.status(HttpStatus.CREATED).body(newPhoto);
+    }
 }

--- a/src/main/java/com/muczynski/library/domain/Author.java
+++ b/src/main/java/com/muczynski/library/domain/Author.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -24,4 +25,7 @@ public class Author {
     private String birthCountry;
     private String nationality;
     private String briefBiography;
+
+    @OneToMany(mappedBy = "author", cascade = jakarta.persistence.CascadeType.ALL, orphanRemoval = true)
+    private java.util.List<Photo> photos;
 }

--- a/src/main/java/com/muczynski/library/domain/Photo.java
+++ b/src/main/java/com/muczynski/library/domain/Photo.java
@@ -25,4 +25,8 @@ public class Photo {
     @ManyToOne
     @JoinColumn(name = "book_id")
     private Book book;
+
+    @ManyToOne
+    @JoinColumn(name = "author_id")
+    private Author author;
 }

--- a/src/main/java/com/muczynski/library/dto/PhotoDto.java
+++ b/src/main/java/com/muczynski/library/dto/PhotoDto.java
@@ -8,4 +8,6 @@ public class PhotoDto {
     private String contentType;
     private String caption;
     private int rotation;
+    private Long bookId;
+    private Long authorId;
 }

--- a/src/main/java/com/muczynski/library/mapper/AuthorMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/AuthorMapper.java
@@ -3,9 +3,11 @@ package com.muczynski.library.mapper;
 import com.muczynski.library.domain.Author;
 import com.muczynski.library.dto.AuthorDto;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface AuthorMapper {
     AuthorDto toDto(Author author);
+    @Mapping(target = "photos", ignore = true)
     Author toEntity(AuthorDto authorDto);
 }

--- a/src/main/java/com/muczynski/library/mapper/PhotoMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/PhotoMapper.java
@@ -7,9 +7,12 @@ import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface PhotoMapper {
+    @Mapping(source = "book.id", target = "bookId")
+    @Mapping(source = "author.id", target = "authorId")
     PhotoDto toDto(Photo photo);
 
     @Mapping(target = "image", ignore = true)
     @Mapping(target = "book", ignore = true)
+    @Mapping(target = "author", ignore = true)
     Photo toEntity(PhotoDto photoDto);
 }

--- a/src/main/java/com/muczynski/library/repository/PhotoRepository.java
+++ b/src/main/java/com/muczynski/library/repository/PhotoRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
     List<Photo> findByBookId(Long bookId);
+    List<Photo> findByAuthorId(Long authorId);
 }


### PR DESCRIPTION
This change introduces the ability to attach photos to authors, mirroring the existing functionality for books.

- The `Photo` entity has been updated to include a many-to-one relationship with the `Author` entity.
- The `Author` entity has been updated to include a one-to-many relationship with the `Photo` entity.
- The `PhotoService` now includes methods for adding and retrieving photos for authors.
- The `AuthorController` has a new endpoint for uploading photos to an author.
- The `PhotoMapper` and `PhotoDto` have been updated to include the author ID.