### PR TITLE
feat: Improve error messages for search and other pages

### DIFF
--- a/src/main/java/com/muczynski/library/controller/SearchController.java
+++ b/src/main/java/com/muczynski/library/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.muczynski.library.controller;
 
 import com.muczynski.library.service.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +19,12 @@ public class SearchController {
     private SearchService searchService;
 
     @GetMapping
-    public ResponseEntity<Map<String, Object>> search(@RequestParam String query, @RequestParam int page, @RequestParam int size) {
-        Map<String, Object> results = searchService.search(query, page, size);
-        return ResponseEntity.ok(results);
+    public ResponseEntity<?> search(@RequestParam String query, @RequestParam int page, @RequestParam int size) {
+        try {
+            Map<String, Object> results = searchService.search(query, page, size);
+            return ResponseEntity.ok(results);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/service/SearchService.java
+++ b/src/main/java/com/muczynski/library/service/SearchService.java
@@ -35,6 +35,9 @@ public class SearchService {
     private AuthorMapper authorMapper;
 
     public Map<String, Object> search(String query, int page, int size) {
+        if (query == null || query.trim().isEmpty()) {
+            throw new IllegalArgumentException("Query cannot be empty");
+        }
         Pageable pageable = PageRequest.of(page, size);
         Page<Book> bookPage = bookRepository.findByTitleContainingIgnoreCase(query, pageable);
         Page<Author> authorPage = authorRepository.findByNameContainingIgnoreCase(query, pageable);

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -78,7 +78,8 @@ async function fetchData(url) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         const contentType = response.headers.get('content-type');
@@ -154,7 +155,8 @@ async function postData(url, data, isFormData = false, includeCsrf = true) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         const contentType = response.headers.get('content-type');
@@ -231,7 +233,8 @@ async function putData(url, data, includeCsrf = true) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         const contentType = response.headers.get('content-type');
@@ -305,7 +308,8 @@ async function deleteData(url) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         return response.ok;


### PR DESCRIPTION
- In `SearchController`, catch exceptions from the `SearchService` and return the exception message in the response body with a 500 status.
- Add validation in `SearchService` to throw an `IllegalArgumentException` for empty search queries.
- In `app.js`, update `fetchData`, `postData`, `putData`, and `deleteData` to read the error message from the response body when the status is not 'ok'.
- Remove exclamation points from user-facing error messages in `app.js`.