### PR TITLE
feat: Apply consistent error handling across all controllers

### DIFF
--- a/src/main/java/com/muczynski/library/controller/AppliedController.java
+++ b/src/main/java/com/muczynski/library/controller/AppliedController.java
@@ -28,45 +28,69 @@ public class AppliedController {
 
     @PostMapping("/public/register")
     public ResponseEntity<?> register(@RequestBody RegistrationRequest registrationRequest) {
-        Applied applied = new Applied();
-        applied.setName(registrationRequest.getUsername());
-        applied.setPassword(registrationRequest.getPassword());
-        appliedService.createApplied(applied);
-        return ResponseEntity.ok().build();
+        try {
+            Applied applied = new Applied();
+            applied.setName(registrationRequest.getUsername());
+            applied.setPassword(registrationRequest.getPassword());
+            appliedService.createApplied(applied);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/applied")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<List<Applied>> getAllApplied() {
-        List<Applied> applied = appliedService.getAllApplied();
-        return ResponseEntity.ok(applied);
+    public ResponseEntity<?> getAllApplied() {
+        try {
+            List<Applied> applied = appliedService.getAllApplied();
+            return ResponseEntity.ok(applied);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PostMapping("/applied")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Applied> createApplied(@RequestBody Applied applied) {
-        Applied createdApplied = appliedService.createApplied(applied);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdApplied);
+    public ResponseEntity<?> createApplied(@RequestBody Applied applied) {
+        try {
+            Applied createdApplied = appliedService.createApplied(applied);
+            return ResponseEntity.status(HttpStatus.CREATED).body(createdApplied);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/applied/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Applied> updateApplied(@PathVariable Long id, @RequestBody Applied applied) {
-        Applied updatedApplied = appliedService.updateApplied(id, applied);
-        return ResponseEntity.ok(updatedApplied);
+    public ResponseEntity<?> updateApplied(@PathVariable Long id, @RequestBody Applied applied) {
+        try {
+            Applied updatedApplied = appliedService.updateApplied(id, applied);
+            return ResponseEntity.ok(updatedApplied);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/applied/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> deleteApplied(@PathVariable Long id) {
-        appliedService.deleteApplied(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> deleteApplied(@PathVariable Long id) {
+        try {
+            appliedService.deleteApplied(id);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PostMapping("/applied/{id}/approve")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> approveApplication(@PathVariable Long id) {
-        appliedService.approveApplication(id);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> approveApplication(@PathVariable Long id) {
+        try {
+            appliedService.approveApplication(id);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/controller/AuthorController.java
+++ b/src/main/java/com/muczynski/library/controller/AuthorController.java
@@ -25,28 +25,44 @@ public class AuthorController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<AuthorDto> createAuthor(@RequestBody AuthorDto authorDto) {
-        AuthorDto created = authorService.createAuthor(authorDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    public ResponseEntity<?> createAuthor(@RequestBody AuthorDto authorDto) {
+        try {
+            AuthorDto created = authorService.createAuthor(authorDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping
-    public ResponseEntity<List<AuthorDto>> getAllAuthors() {
-        List<AuthorDto> authors = authorService.getAllAuthors();
-        return ResponseEntity.ok(authors);
+    public ResponseEntity<?> getAllAuthors() {
+        try {
+            List<AuthorDto> authors = authorService.getAllAuthors();
+            return ResponseEntity.ok(authors);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<AuthorDto> getAuthorById(@PathVariable Long id) {
-        AuthorDto author = authorService.getAuthorById(id);
-        return author != null ? ResponseEntity.ok(author) : ResponseEntity.notFound().build();
+    public ResponseEntity<?> getAuthorById(@PathVariable Long id) {
+        try {
+            AuthorDto author = authorService.getAuthorById(id);
+            return author != null ? ResponseEntity.ok(author) : ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<AuthorDto> updateAuthor(@PathVariable Long id, @RequestBody AuthorDto authorDto) {
-        AuthorDto updated = authorService.updateAuthor(id, authorDto);
-        return ResponseEntity.ok(updated);
+    public ResponseEntity<?> updateAuthor(@PathVariable Long id, @RequestBody AuthorDto authorDto) {
+        try {
+            AuthorDto updated = authorService.updateAuthor(id, authorDto);
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/{id}")
@@ -65,8 +81,12 @@ public class AuthorController {
 
     @PostMapping("/{id}/photos")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<PhotoDto> addPhotoToAuthor(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
-        PhotoDto newPhoto = photoService.addPhotoToAuthor(id, file);
-        return ResponseEntity.status(HttpStatus.CREATED).body(newPhoto);
+    public ResponseEntity<?> addPhotoToAuthor(@PathVariable Long id, @RequestParam("file") MultipartFile file) {
+        try {
+            PhotoDto newPhoto = photoService.addPhotoToAuthor(id, file);
+            return ResponseEntity.status(HttpStatus.CREATED).body(newPhoto);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/controller/BookController.java
+++ b/src/main/java/com/muczynski/library/controller/BookController.java
@@ -27,28 +27,44 @@ public class BookController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<BookDto> createBook(@RequestBody BookDto bookDto) {
-        BookDto created = bookService.createBook(bookDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    public ResponseEntity<?> createBook(@RequestBody BookDto bookDto) {
+        try {
+            BookDto created = bookService.createBook(bookDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping
-    public ResponseEntity<List<BookDto>> getAllBooks() {
-        List<BookDto> books = bookService.getAllBooks();
-        return ResponseEntity.ok(books);
+    public ResponseEntity<?> getAllBooks() {
+        try {
+            List<BookDto> books = bookService.getAllBooks();
+            return ResponseEntity.ok(books);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<BookDto> getBookById(@PathVariable Long id) {
-        BookDto book = bookService.getBookById(id);
-        return book != null ? ResponseEntity.ok(book) : ResponseEntity.notFound().build();
+    public ResponseEntity<?> getBookById(@PathVariable Long id) {
+        try {
+            BookDto book = bookService.getBookById(id);
+            return book != null ? ResponseEntity.ok(book) : ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<BookDto> updateBook(@PathVariable Long id, @RequestBody BookDto bookDto) {
-        BookDto updated = bookService.updateBook(id, bookDto);
-        return ResponseEntity.ok(updated);
+    public ResponseEntity<?> updateBook(@PathVariable Long id, @RequestBody BookDto bookDto) {
+        try {
+            BookDto updated = bookService.updateBook(id, bookDto);
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/{id}")
@@ -68,43 +84,67 @@ public class BookController {
 
     @PostMapping("/{bookId}/photos")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<PhotoDto> addPhotoToBook(@PathVariable Long bookId, @RequestParam("file") MultipartFile file) {
-        PhotoDto created = photoService.addPhoto(bookId, file);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    public ResponseEntity<?> addPhotoToBook(@PathVariable Long bookId, @RequestParam("file") MultipartFile file) {
+        try {
+            PhotoDto created = photoService.addPhoto(bookId, file);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{bookId}/photos")
-    public ResponseEntity<List<PhotoDto>> getPhotosByBook(@PathVariable Long bookId) {
-        List<PhotoDto> photos = photoService.getPhotosByBookId(bookId);
-        return ResponseEntity.ok(photos);
+    public ResponseEntity<?> getPhotosByBook(@PathVariable Long bookId) {
+        try {
+            List<PhotoDto> photos = photoService.getPhotosByBookId(bookId);
+            return ResponseEntity.ok(photos);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{bookId}/photos/{photoId}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<PhotoDto> updatePhoto(@PathVariable Long bookId, @PathVariable Long photoId, @RequestBody PhotoDto photoDto) {
-        PhotoDto updated = photoService.updatePhoto(photoId, photoDto);
-        return ResponseEntity.ok(updated);
+    public ResponseEntity<?> updatePhoto(@PathVariable Long bookId, @PathVariable Long photoId, @RequestBody PhotoDto photoDto) {
+        try {
+            PhotoDto updated = photoService.updatePhoto(photoId, photoDto);
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/{bookId}/photos/{photoId}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> deletePhoto(@PathVariable Long bookId, @PathVariable Long photoId) {
-        photoService.deletePhoto(photoId);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> deletePhoto(@PathVariable Long bookId, @PathVariable Long photoId) {
+        try {
+            photoService.deletePhoto(photoId);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{bookId}/photos/{photoId}/rotate-cw")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> rotatePhotoCW(@PathVariable Long bookId, @PathVariable Long photoId) {
-        photoService.rotatePhoto(photoId, true);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> rotatePhotoCW(@PathVariable Long bookId, @PathVariable Long photoId) {
+        try {
+            photoService.rotatePhoto(photoId, true);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{bookId}/photos/{photoId}/rotate-ccw")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> rotatePhotoCCW(@PathVariable Long bookId, @PathVariable Long photoId) {
-        photoService.rotatePhoto(photoId, false);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> rotatePhotoCCW(@PathVariable Long bookId, @PathVariable Long photoId) {
+        try {
+            photoService.rotatePhoto(photoId, false);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{id}/book-by-photo")
@@ -113,22 +153,30 @@ public class BookController {
         try {
             BookDto updated = bookService.generateTempBook(id);
             return ResponseEntity.ok(updated);
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
     }
 
     @PutMapping("/{bookId}/photos/{photoId}/move-left")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> movePhotoLeft(@PathVariable Long bookId, @PathVariable Long photoId) {
-        photoService.movePhotoLeft(bookId, photoId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> movePhotoLeft(@PathVariable Long bookId, @PathVariable Long photoId) {
+        try {
+            photoService.movePhotoLeft(bookId, photoId);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{bookId}/photos/{photoId}/move-right")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> movePhotoRight(@PathVariable Long bookId, @PathVariable Long photoId) {
-        photoService.movePhotoRight(bookId, photoId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<?> movePhotoRight(@PathVariable Long bookId, @PathVariable Long photoId) {
+        try {
+            photoService.movePhotoRight(bookId, photoId);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/controller/LibraryController.java
+++ b/src/main/java/com/muczynski/library/controller/LibraryController.java
@@ -19,34 +19,54 @@ public class LibraryController {
 
     @PostMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<LibraryDto> createLibrary(@RequestBody LibraryDto libraryDto) {
-        LibraryDto created = libraryService.createLibrary(libraryDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    public ResponseEntity<?> createLibrary(@RequestBody LibraryDto libraryDto) {
+        try {
+            LibraryDto created = libraryService.createLibrary(libraryDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping
-    public ResponseEntity<List<LibraryDto>> getAllLibraries() {
-        List<LibraryDto> libraries = libraryService.getAllLibraries();
-        return ResponseEntity.ok(libraries);
+    public ResponseEntity<?> getAllLibraries() {
+        try {
+            List<LibraryDto> libraries = libraryService.getAllLibraries();
+            return ResponseEntity.ok(libraries);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<LibraryDto> getLibraryById(@PathVariable Long id) {
-        LibraryDto library = libraryService.getLibraryById(id);
-        return library != null ? ResponseEntity.ok(library) : ResponseEntity.notFound().build();
+    public ResponseEntity<?> getLibraryById(@PathVariable Long id) {
+        try {
+            LibraryDto library = libraryService.getLibraryById(id);
+            return library != null ? ResponseEntity.ok(library) : ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<LibraryDto> updateLibrary(@PathVariable Long id, @RequestBody LibraryDto libraryDto) {
-        LibraryDto updated = libraryService.updateLibrary(id, libraryDto);
-        return ResponseEntity.ok(updated);
+    public ResponseEntity<?> updateLibrary(@PathVariable Long id, @RequestBody LibraryDto libraryDto) {
+        try {
+            LibraryDto updated = libraryService.updateLibrary(id, libraryDto);
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> deleteLibrary(@PathVariable Long id) {
-        libraryService.deleteLibrary(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> deleteLibrary(@PathVariable Long id) {
+        try {
+            libraryService.deleteLibrary(id);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/controller/LoanController.java
+++ b/src/main/java/com/muczynski/library/controller/LoanController.java
@@ -19,43 +19,67 @@ public class LoanController {
 
     @PostMapping("/checkout")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<LoanDto> checkoutBook(@RequestBody LoanDto loanDto) {
-        LoanDto created = loanService.checkoutBook(loanDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    public ResponseEntity<?> checkoutBook(@RequestBody LoanDto loanDto) {
+        try {
+            LoanDto created = loanService.checkoutBook(loanDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(created);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/return/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<LoanDto> returnBook(@PathVariable Long id) {
-        LoanDto updated = loanService.returnBook(id);
-        return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
+    public ResponseEntity<?> returnBook(@PathVariable Long id) {
+        try {
+            LoanDto updated = loanService.returnBook(id);
+            return updated != null ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<List<LoanDto>> getAllLoans(@RequestParam(defaultValue = "false") boolean showAll) {
-        List<LoanDto> loans = loanService.getAllLoans(showAll);
-        return ResponseEntity.ok(loans);
+    public ResponseEntity<?> getAllLoans(@RequestParam(defaultValue = "false") boolean showAll) {
+        try {
+            List<LoanDto> loans = loanService.getAllLoans(showAll);
+            return ResponseEntity.ok(loans);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<LoanDto> getLoanById(@PathVariable Long id) {
-        LoanDto loan = loanService.getLoanById(id);
-        return loan != null ? ResponseEntity.ok(loan) : ResponseEntity.notFound().build();
+    public ResponseEntity<?> getLoanById(@PathVariable Long id) {
+        try {
+            LoanDto loan = loanService.getLoanById(id);
+            return loan != null ? ResponseEntity.ok(loan) : ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<LoanDto> updateLoan(@PathVariable Long id, @RequestBody LoanDto loanDto) {
-        LoanDto updated = loanService.updateLoan(id, loanDto);
-        return ResponseEntity.ok(updated);
+    public ResponseEntity<?> updateLoan(@PathVariable Long id, @RequestBody LoanDto loanDto) {
+        try {
+            LoanDto updated = loanService.updateLoan(id, loanDto);
+            return ResponseEntity.ok(updated);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<Void> deleteLoan(@PathVariable Long id) {
-        loanService.deleteLoan(id);
-        return ResponseEntity.noContent().build();
+    public ResponseEntity<?> deleteLoan(@PathVariable Long id) {
+        try {
+            loanService.deleteLoan(id);
+            return ResponseEntity.noContent().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/controller/SearchController.java
+++ b/src/main/java/com/muczynski/library/controller/SearchController.java
@@ -2,6 +2,7 @@ package com.muczynski.library.controller;
 
 import com.muczynski.library.service.SearchService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,8 +19,12 @@ public class SearchController {
     private SearchService searchService;
 
     @GetMapping
-    public ResponseEntity<Map<String, Object>> search(@RequestParam String query, @RequestParam int page, @RequestParam int size) {
-        Map<String, Object> results = searchService.search(query, page, size);
-        return ResponseEntity.ok(results);
+    public ResponseEntity<?> search(@RequestParam String query, @RequestParam int page, @RequestParam int size) {
+        try {
+            Map<String, Object> results = searchService.search(query, page, size);
+            return ResponseEntity.ok(results);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/muczynski/library/controller/UserController.java
+++ b/src/main/java/com/muczynski/library/controller/UserController.java
@@ -46,47 +46,71 @@ public class UserController {
 
     @GetMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<List<UserDto>> getAllUsers() {
-        List<UserDto> users = userService.getAllUsers();
-        return ResponseEntity.ok(users);
+    public ResponseEntity<?> getAllUsers() {
+        try {
+            List<UserDto> users = userService.getAllUsers();
+            return ResponseEntity.ok(users);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @GetMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<UserDto> getUserById(@PathVariable Long id) {
-        UserDto user = userService.getUserById(id);
-        return user != null ? ResponseEntity.ok(user) : ResponseEntity.notFound().build();
+    public ResponseEntity<?> getUserById(@PathVariable Long id) {
+        try {
+            UserDto user = userService.getUserById(id);
+            return user != null ? ResponseEntity.ok(user) : ResponseEntity.notFound().build();
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PostMapping
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<UserDto> createUser(@RequestBody CreateUserDto createUserDto) {
-        UserDto createdUser = userService.createUser(createUserDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
+    public ResponseEntity<?> createUser(@RequestBody CreateUserDto createUserDto) {
+        try {
+            UserDto createdUser = userService.createUser(createUserDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PostMapping("/public/register")
-    public ResponseEntity<UserDto> registerUser(@RequestBody CreateUserDto createUserDto) {
-        if (!"USER".equals(createUserDto.getRole())) {
-            return ResponseEntity.badRequest().build();
+    public ResponseEntity<?> registerUser(@RequestBody CreateUserDto createUserDto) {
+        try {
+            if (!"USER".equals(createUserDto.getRole())) {
+                return ResponseEntity.badRequest().build();
+            }
+            UserDto createdUser = userService.createUser(createUserDto);
+            return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
         }
-        UserDto createdUser = userService.createUser(createUserDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
     @PutMapping("/{id}")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<UserDto> updateUser(@PathVariable Long id, @RequestBody CreateUserDto createUserDto) {
-        UserDto updatedUser = userService.updateUser(id, createUserDto);
-        return ResponseEntity.ok(updatedUser);
+    public ResponseEntity<?> updateUser(@PathVariable Long id, @RequestBody CreateUserDto createUserDto) {
+        try {
+            UserDto updatedUser = userService.updateUser(id, createUserDto);
+            return ResponseEntity.ok(updatedUser);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @PutMapping("/{id}/apikey")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
-    public ResponseEntity<UserDto> updateApiKey(@PathVariable Long id, @RequestBody UserDto userDto) {
-        userService.updateApiKey(id, userDto.getXaiApiKey());
-        UserDto updatedUser = userService.getUserById(id);
-        return ResponseEntity.ok(updatedUser);
+    public ResponseEntity<?> updateApiKey(@PathVariable Long id, @RequestBody UserDto userDto) {
+        try {
+            userService.updateApiKey(id, userDto.getXaiApiKey());
+            UserDto updatedUser = userService.getUserById(id);
+            return ResponseEntity.ok(updatedUser);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/muczynski/library/service/SearchService.java
+++ b/src/main/java/com/muczynski/library/service/SearchService.java
@@ -35,6 +35,9 @@ public class SearchService {
     private AuthorMapper authorMapper;
 
     public Map<String, Object> search(String query, int page, int size) {
+        if (query == null || query.trim().isEmpty()) {
+            throw new IllegalArgumentException("Query cannot be empty");
+        }
         Pageable pageable = PageRequest.of(page, size);
         Page<Book> bookPage = bookRepository.findByTitleContainingIgnoreCase(query, pageable);
         Page<Author> authorPage = authorRepository.findByNameContainingIgnoreCase(query, pageable);

--- a/src/main/resources/static/js/app.js
+++ b/src/main/resources/static/js/app.js
@@ -78,7 +78,8 @@ async function fetchData(url) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         const contentType = response.headers.get('content-type');
@@ -154,7 +155,8 @@ async function postData(url, data, isFormData = false, includeCsrf = true) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         const contentType = response.headers.get('content-type');
@@ -231,7 +233,8 @@ async function putData(url, data, includeCsrf = true) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         const contentType = response.headers.get('content-type');
@@ -305,7 +308,8 @@ async function deleteData(url) {
         }
 
         if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
+            const errorText = await response.text();
+            throw new Error(errorText || `HTTP error status: ${response.status}`);
         }
 
         return response.ok;


### PR DESCRIPTION
This change extends the improved error handling to all relevant controllers, including `AuthorController`, `BookController`, `LibraryController`, `AppliedController`, `LoanController`, and `UserController`.

- All public controller methods are now wrapped in a `try-catch` block to handle exceptions from the service layer.
- When an exception is caught, the controller returns a `ResponseEntity` with a 500 status and the exception message in the response body.
- Specific exception handling for deletion conflicts has been preserved to return a 409 status code where appropriate.