### PR TITLE
feat: Add author photo rotation endpoints

### DIFF
--- a/src/main/java/com/muczynski/library/controller/AuthorController.java
+++ b/src/main/java/com/muczynski/library/controller/AuthorController.java
@@ -113,4 +113,28 @@ public class AuthorController {
             throw e;
         }
     }
+
+    @PutMapping("/{authorId}/photos/{photoId}/rotate-cw")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<?> rotatePhotoCW(@PathVariable Long authorId, @PathVariable Long photoId) {
+        try {
+            photoService.rotateAuthorPhoto(authorId, photoId, true);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            logger.debug("Failed to rotate photo ID {} clockwise for author ID {}: {}", photoId, authorId, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
+
+    @PutMapping("/{authorId}/photos/{photoId}/rotate-ccw")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<?> rotatePhotoCCW(@PathVariable Long authorId, @PathVariable Long photoId) {
+        try {
+            photoService.rotateAuthorPhoto(authorId, photoId, false);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            logger.debug("Failed to rotate photo ID {} counter-clockwise for author ID {}: {}", photoId, authorId, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(e.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/muczynski/library/service/PhotoService.java
+++ b/src/main/java/com/muczynski/library/service/PhotoService.java
@@ -65,6 +65,27 @@ public class PhotoService {
     }
 
     @Transactional
+    public void rotateAuthorPhoto(Long authorId, Long photoId, boolean clockwise) {
+        try {
+            Photo photo = photoRepository.findById(photoId)
+                    .orElseThrow(() -> new RuntimeException("Photo not found"));
+
+            if (photo.getAuthor() == null || !photo.getAuthor().getId().equals(authorId)) {
+                throw new RuntimeException("Photo does not belong to the specified author");
+            }
+
+            int delta = clockwise ? 90 : -90;
+            int currentRotation = photo.getRotation();
+            int newRotation = ((currentRotation + delta) % 360 + 360) % 360;
+            photo.setRotation(newRotation);
+            photoRepository.save(photo);
+        } catch (Exception e) {
+            logger.debug("Failed to rotate photo ID {} for author ID {} (clockwise: {}): {}", photoId, authorId, clockwise, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Transactional
     public PhotoDto addPhotoToAuthor(Long authorId, MultipartFile file) {
         try {
             Author author = authorRepository.findById(authorId)


### PR DESCRIPTION
This commit adds two new endpoints to the `AuthorController` to allow for the rotation of author photos:

- `PUT /api/authors/{authorId}/photos/{photoId}/rotate-cw`
- `PUT /api/authors/{authorId}/photos/{photoId}/rotate-ccw`

The `PhotoService` has been updated to include a new `rotateAuthorPhoto` method that validates that the photo belongs to the specified author before performing the rotation. This addresses a potential data integrity issue where a photo could be modified via an API call referencing an incorrect author.