### PR TITLE
Fix(search): Add @Transactional to resolve LOB stream error

### DIFF
--- a/src/main/java/com/muczynski/library/service/SearchService.java
+++ b/src/main/java/com/muczynski/library/service/SearchService.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -35,6 +36,7 @@ public class SearchService {
     @Autowired
     private AuthorMapper authorMapper;
 
+    @Transactional(readOnly = true)
     public Map<String, Object> search(String query, int page, int size) {
         if (query == null || query.trim().isEmpty()) {
             throw new IllegalArgumentException("Query cannot be empty");


### PR DESCRIPTION
The search endpoint was failing with an "Unable to access lob stream" error. This was caused by lazy-loading of LOB data (e.g., photos) outside of an active database transaction.

This commit resolves the issue by adding the `@Transactional(readOnly = true)` annotation to the `search` method in `SearchService`. This ensures that the entire search operation, including the mapping of entities to DTOs, occurs within a single transaction, preventing the error.