### PR TITLE
feat: Add endpoint to delete author photos

### DIFF
--- a/src/main/java/com/muczynski/library/controller/AuthorController.java
+++ b/src/main/java/com/muczynski/library/controller/AuthorController.java
@@ -114,6 +114,18 @@ public class AuthorController {
         }
     }
 
+    @DeleteMapping("/{authorId}/photos/{photoId}")
+    @PreAuthorize("hasAuthority('LIBRARIAN')")
+    public ResponseEntity<Void> deleteAuthorPhoto(@PathVariable Long authorId, @PathVariable Long photoId) {
+        try {
+            photoService.deleteAuthorPhoto(authorId, photoId);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            logger.debug("Failed to delete photo ID {} for author ID {}: {}", photoId, authorId, e.getMessage(), e);
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     @PutMapping("/{authorId}/photos/{photoId}/rotate-cw")
     @PreAuthorize("hasAuthority('LIBRARIAN')")
     public ResponseEntity<?> rotatePhotoCW(@PathVariable Long authorId, @PathVariable Long photoId) {

--- a/src/main/java/com/muczynski/library/service/PhotoService.java
+++ b/src/main/java/com/muczynski/library/service/PhotoService.java
@@ -65,6 +65,23 @@ public class PhotoService {
     }
 
     @Transactional
+    public void deleteAuthorPhoto(Long authorId, Long photoId) {
+        try {
+            Photo photo = photoRepository.findById(photoId)
+                    .orElseThrow(() -> new RuntimeException("Photo not found"));
+
+            if (photo.getAuthor() == null || !photo.getAuthor().getId().equals(authorId)) {
+                throw new RuntimeException("Photo does not belong to the specified author");
+            }
+
+            photoRepository.delete(photo);
+        } catch (Exception e) {
+            logger.debug("Failed to delete photo ID {} for author ID {}: {}", photoId, authorId, e.getMessage(), e);
+            throw e;
+        }
+    }
+
+    @Transactional
     public void rotateAuthorPhoto(Long authorId, Long photoId, boolean clockwise) {
         try {
             Photo photo = photoRepository.findById(photoId)

--- a/src/test/java/com/muczynski/library/controller/AuthorControllerTest.java
+++ b/src/test/java/com/muczynski/library/controller/AuthorControllerTest.java
@@ -4,6 +4,7 @@ package com.muczynski.library.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.muczynski.library.dto.AuthorDto;
 import com.muczynski.library.service.AuthorService;
+import com.muczynski.library.service.PhotoService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -19,7 +20,9 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,6 +37,9 @@ class AuthorControllerTest {
 
     @MockitoBean
     private AuthorService authorService;
+
+    @MockitoBean
+    private PhotoService photoService;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -78,4 +84,21 @@ class AuthorControllerTest {
                 .andExpect(status().isOk());
     }
 
+    @Test
+    @WithMockUser(authorities = "LIBRARIAN")
+    void deleteAuthorPhoto_Success() throws Exception {
+        doNothing().when(photoService).deleteAuthorPhoto(1L, 1L);
+
+        mockMvc.perform(delete("/api/authors/1/photos/1"))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @WithMockUser(authorities = "LIBRARIAN")
+    void deleteAuthorPhoto_NotFound() throws Exception {
+        doThrow(new RuntimeException("Photo not found")).when(photoService).deleteAuthorPhoto(1L, 1L);
+
+        mockMvc.perform(delete("/api/authors/1/photos/1"))
+                .andExpect(status().isNotFound());
+    }
 }


### PR DESCRIPTION
Adds a new `DELETE` endpoint at `/api/authors/{authorId}/photos/{photoId}` to allow for the deletion of photos associated with an author.

The `PhotoService` is updated with a new `deleteAuthorPhoto` method that ensures a photo belongs to the specified author before deleting it.

Unit tests are added to `AuthorControllerTest` to verify the new endpoint's functionality, including success and not found scenarios.