### PR TITLE
feat: Add loans column to books page

### DIFF
--- a/jules-scratch/verification/verify_loans_column.py
+++ b/jules-scratch/verification/verify_loans_column.py
@@ -1,0 +1,53 @@
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    page.goto("http://localhost:8080")
+
+    # Login
+    page.locator('[data-test="menu-login"]').click()
+    page.locator('[data-test="login-username"]').fill("librarian")
+    page.locator('[data-test="login-password"]').fill("divinemercy")
+    page.locator('[data-test="login-submit"]').click()
+
+    # Wait for main content to load
+    expect(page.locator('[data-test="main-content"]')).to_be_visible()
+
+    # Go to test data page and generate data
+    page.locator('[data-test="menu-test-data"]').click()
+    page.locator('[data-test="num-books"]').fill("1")
+    page.locator('[data-test="generate-test-data-btn"]').click()
+    page.locator('[data-test="generate-test-loans-btn"]').click()
+
+    # Go to books page and create a withdrawn book
+    page.locator('[data-test="menu-books"]').click()
+    page.locator('[data-test="new-book-title"]').fill("Withdrawn Book")
+    page.locator('[data-test="new-book-status"]').select_option("WITHDRAWN")
+    page.locator('[data-test="add-book-btn"]').click()
+    # Wait for the book to be added
+    expect(page.locator('[data-test="book-title"]:has-text("Withdrawn Book")').first).to_be_visible()
+
+
+    # Create a lost book
+    page.locator('[data-test="new-book-title"]').fill("Lost Book")
+    page.locator('[data-test="new-book-status"]').select_option("LOST")
+    page.locator('[data-test="add-book-btn"]').click()
+    # Wait for the book to be added
+    expect(page.locator('[data-test="book-title"]:has-text("Lost Book")').first).to_be_visible()
+
+    # Wait for the table to be visible
+    book_table = page.locator('[data-test="book-table"]')
+    expect(book_table).to_be_visible()
+
+    page.wait_for_timeout(1000) # 1 second wait
+
+    # Take a screenshot
+    page.screenshot(path="loans-column.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)

--- a/src/main/java/com/muczynski/library/dto/BookDto.java
+++ b/src/main/java/com/muczynski/library/dto/BookDto.java
@@ -21,4 +21,5 @@ public class BookDto {
     private Long libraryId;
     private Long firstPhotoId;
     private Integer firstPhotoRotation;
+    private Long loanCount;
 }

--- a/src/main/java/com/muczynski/library/mapper/BookMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/BookMapper.java
@@ -6,9 +6,14 @@ import com.muczynski.library.domain.Book;
 import com.muczynski.library.domain.Library;
 import com.muczynski.library.dto.BookDto;
 import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.muczynski.library.repository.LoanRepository;
 
 @Service
 public class BookMapper {
+
+    @Autowired
+    private LoanRepository loanRepository;
 
     public BookDto toDto(Book book) {
         if (book == null) {
@@ -35,6 +40,8 @@ public class BookMapper {
             bookDto.setFirstPhotoId(book.getPhotos().get(0).getId());
             bookDto.setFirstPhotoRotation(book.getPhotos().get(0).getRotation());
         }
+
+        bookDto.setLoanCount(loanRepository.countByBookIdAndReturnDateIsNull(book.getId()));
 
         return bookDto;
     }

--- a/src/main/java/com/muczynski/library/repository/LoanRepository.java
+++ b/src/main/java/com/muczynski/library/repository/LoanRepository.java
@@ -14,6 +14,7 @@ public interface LoanRepository extends JpaRepository<Loan, Long> {
     List<Loan> findAllByReturnDateIsNullOrderByDueDateAsc();
     List<Loan> findAllByOrderByDueDateAsc();
     long countByBookId(Long bookId);
+    long countByBookIdAndReturnDateIsNull(Long bookId);
     long countByUserIdAndReturnDateIsNull(Long userId);
     void deleteByUserId(Long userId);
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -154,6 +154,7 @@
                 <tr>
                     <th scope="col">Photo</th>
                     <th scope="col">Book</th>
+                    <th scope="col" class="librarian-only">Loans</th>
                     <th scope="col">Actions</th>
                 </tr>
                 </thead>

--- a/src/main/resources/static/js/books.js
+++ b/src/main/resources/static/js/books.js
@@ -30,6 +30,15 @@ async function loadBooks() {
             titleCell.appendChild(titleSpan);
             row.appendChild(titleCell);
 
+            const loansCell = document.createElement('td');
+            loansCell.className = 'librarian-only';
+            if (book.status === 'WITHDRAWN' || book.status === 'LOST') {
+                loansCell.textContent = book.status.toLowerCase();
+            } else if (book.loanCount > 0) {
+                loansCell.textContent = book.loanCount;
+            }
+            row.appendChild(loansCell);
+
             const actionsCell = document.createElement('td');
             if (isLibrarian) {
                 const editBtn = document.createElement('button');


### PR DESCRIPTION
Adds a 'Loans' column to the Books page to display the number of active loans for each book.

- If a book is 'withdrawn' or 'lost', the status is displayed in the column.
- If a book has active loans, the number of loans is displayed.
- If a book has no active loans, the column is left blank.

Backend changes include:
- Added `loanCount` to `BookDto`.
- Updated `BookMapper` to populate `loanCount`.
- Added `countByBookIdAndReturnDateIsNull` to `LoanRepository`.

Frontend changes include:
- Added 'Loans' column to the book table in `index.html`.
- Updated `books.js` to render the loan count or status.