### PR TITLE
Fix: Handle null values in author and photo sorting

### DIFF
--- a/src/main/java/com/muczynski/library/mapper/AuthorMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/AuthorMapper.java
@@ -23,7 +23,7 @@ public interface AuthorMapper {
     @AfterMapping
     default void afterToDto(Author author, @MappingTarget AuthorDto dto) {
         author.getPhotos().stream()
-                .min(Comparator.comparing(Photo::getPhotoOrder))
+                .min(Comparator.nullsLast(Comparator.comparing(Photo::getPhotoOrder, Comparator.nullsLast(Comparator.naturalOrder()))))
                 .ifPresent(photo -> dto.setFirstPhotoId(photo.getId()));
     }
 }

--- a/src/main/java/com/muczynski/library/service/AuthorService.java
+++ b/src/main/java/com/muczynski/library/service/AuthorService.java
@@ -37,8 +37,9 @@ public class AuthorService {
         return authorRepository.findAll().stream()
                 .map(authorMapper::toDto)
                 .sorted(Comparator.comparing(author -> {
-                    String[] nameParts = author.getName().split(" ");
-                    return nameParts.length > 1 ? nameParts[nameParts.length - 1] : author.getName();
+                    String name = author.getName() == null ? "" : author.getName();
+                    String[] nameParts = name.split(" ");
+                    return nameParts.length > 1 ? nameParts[nameParts.length - 1] : name;
                 }))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
This commit addresses two separate `NullPointerException`s that occurred due to unsafe sorting operations.

The first issue was in `AuthorService`, where sorting authors by last name would fail if an author's name was `null`. This was resolved by adding a null check to treat `null` names as empty strings during the sorting process.

The second issue was in `AuthorMapper`, where finding the first photo for an author would fail if the `photoOrder` was `null`. This was fixed by using a null-safe comparator (`Comparator.nullsLast`) to handle `null` photo orders gracefully.