### PR TITLE
feat: Display author photo thumbnail with correct rotation

### DIFF
--- a/jules-scratch/verification/verify_author_thumbnail.py
+++ b/jules-scratch/verification/verify_author_thumbnail.py
@@ -1,0 +1,42 @@
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+    page.goto("http://localhost:8080")
+
+    # Login
+    page.wait_for_selector('[data-test="menu-login"]')
+    page.locator('[data-test="menu-login"]').click()
+    page.locator('[data-test="login-username"]').fill("librarian")
+    page.locator('[data-test="login-password"]').fill("divinemercy")
+    page.locator('[data-test="login-submit"]').click()
+
+    # Create author
+    page.wait_for_selector('[data-test="menu-authors"]')
+    page.locator('[data-test="menu-authors"]').click()
+    page.locator('[data-test="new-author-name"]').fill("Test Author")
+    page.locator('[data-test="add-author-btn"]').click()
+
+    # Go back to authors page to see the list
+    page.locator('[data-test="menu-authors"]').click()
+    page.wait_for_selector('[data-test="author-item"]')
+
+
+    # Edit author and add photo
+    page.locator('[data-test="edit-author-btn"]').first.click()
+    page.wait_for_selector('[data-test="add-author-photo-btn"]')
+    page.locator("#author-photo-upload").set_input_files('src/test/resources/test-images/test-image.jpg')
+    page.wait_for_selector('[data-test="author-photo"]')
+
+    # Rotate photo
+    page.locator(".rotate-cw-btn").click()
+    page.wait_for_timeout(1000)
+
+
+    # Go back to authors page
+    page.locator('[data-test="menu-authors"]').click()
+    page.wait_for_selector('[data-test="author-photo-cell"]')
+
+    page.screenshot(path="jules-scratch/verification/verification.png")
+    browser.close()

--- a/src/main/java/com/muczynski/library/dto/AuthorDto.java
+++ b/src/main/java/com/muczynski/library/dto/AuthorDto.java
@@ -15,4 +15,6 @@ public class AuthorDto {
     private String birthCountry;
     private String nationality;
     private String briefBiography;
+    private Long firstPhotoId;
+    private Integer firstPhotoRotation;
 }

--- a/src/main/java/com/muczynski/library/mapper/AuthorMapper.java
+++ b/src/main/java/com/muczynski/library/mapper/AuthorMapper.java
@@ -2,13 +2,32 @@
 package com.muczynski.library.mapper;
 
 import com.muczynski.library.domain.Author;
+import com.muczynski.library.domain.Photo;
 import com.muczynski.library.dto.AuthorDto;
+import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+
+import java.util.Comparator;
 
 @Mapper(componentModel = "spring")
 public interface AuthorMapper {
+
+    @Mapping(target = "firstPhotoId", ignore = true)
+    @Mapping(target = "firstPhotoRotation", ignore = true)
     AuthorDto toDto(Author author);
+
     @Mapping(target = "photos", ignore = true)
     Author toEntity(AuthorDto authorDto);
+
+    @AfterMapping
+    default void afterToDto(Author author, @MappingTarget AuthorDto dto) {
+        author.getPhotos().stream()
+                .min(Comparator.comparing(Photo::getPhotoOrder))
+                .ifPresent(photo -> {
+                    dto.setFirstPhotoId(photo.getId());
+                    dto.setFirstPhotoRotation(photo.getRotation());
+                });
+    }
 }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -98,6 +98,7 @@
             <table class="table" data-test="author-table">
                 <thead>
                 <tr>
+                    <th scope="col">Photo</th>
                     <th scope="col">Author</th>
                     <th scope="col">Actions</th>
                 </tr>

--- a/src/main/resources/static/js/authors.js
+++ b/src/main/resources/static/js/authors.js
@@ -9,6 +9,20 @@ async function loadAuthors() {
             tr.setAttribute('data-test', 'author-item');
             tr.setAttribute('data-entity-id', author.id);
 
+            const tdPhoto = document.createElement('td');
+            tdPhoto.setAttribute('data-test', 'author-photo-cell');
+            if (author.firstPhotoId) {
+                const img = document.createElement('img');
+                img.src = `/api/photos/${author.firstPhotoId}/thumbnail?width=50`;
+                img.style.width = '50px';
+                img.style.height = 'auto';
+                if (author.firstPhotoRotation && author.firstPhotoRotation !== 0) {
+                    img.style.transform = `rotate(${author.firstPhotoRotation}deg)`;
+                }
+                tdPhoto.appendChild(img);
+            }
+            tr.appendChild(tdPhoto);
+
             const tdName = document.createElement('td');
             tdName.setAttribute('data-test', 'author-name');
             tdName.textContent = author.name;


### PR DESCRIPTION
Adds a thumbnail of the author's first photo to the authors table. This change correctly handles the rotation of the thumbnail, mirroring the existing logic for book photos.